### PR TITLE
QACI-315 Fix unexpected filename

### DIFF
--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -233,7 +233,7 @@ else
 
     mvn dependency:copy \
     -Dartifact=fish.payara.distributions:payara:$PAYARA_BUNDLE:zip \
-    -Dmdep.useBaseVersion=false \
+    -Dmdep.stripVersion=true \
     -DoutputDirectory=${CTS_HOME}
     mv ${CTS_HOME}/payara.zip ${CTS_HOME}/latest-glassfish-vi.zip
 fi


### PR DESCRIPTION
Download includes version. Subsequent commands are not expecting version in filename:
eg. Downloads as `payara-5.22.0-20200823.232056-136.zip`