### PR TITLE
QACI-315 Fixed original behavior and also allowing to use PAYARA_VERSION and mvn

### DIFF
--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -222,17 +222,23 @@ echo "Java home for VI: $JAVA_HOME_VI"
 
 ##### installVI.sh starts here #####
 
+if [ -z "${GF_VI_BUNDLE_URL}" ]; then
+    echo "Using GF_BUNDLE_URL for GF VI bundle: $GF_BUNDLE_URL"
+    export GF_VI_BUNDLE_URL=$GF_BUNDLE_URL
+fi
+
 if [ -z "${GF_VI_TOPLEVEL_DIR}" ]; then
     echo "Using glassfish5 for GF_VI_TOPLEVEL_DIR"
     export GF_VI_TOPLEVEL_DIR=glassfish5
 fi
 
-if [[ ${PAYARA_BUNDLE^^} == HTTP* ]]; then
-    wget --progress=bar:force --no-cache $PAYARA_BUNDLE -O ${CTS_HOME}/latest-glassfish-vi.zip
-else
 
+
+if [[ -z "${PAYARA_VERSION}" ]]; then
+    wget --progress=bar:force --no-cache $GF_VI_BUNDLE_URL -O ${CTS_HOME}/latest-glassfish-vi.zip
+else
     mvn dependency:copy \
-    -Dartifact=fish.payara.distributions:payara:$PAYARA_BUNDLE:zip \
+    -Dartifact=fish.payara.distributions:payara:$PAYARA_VERSION:zip \
     -Dmdep.stripVersion=true \
     -DoutputDirectory=${CTS_HOME}
     mv ${CTS_HOME}/payara.zip ${CTS_HOME}/latest-glassfish-vi.zip

--- a/run.sh
+++ b/run.sh
@@ -34,7 +34,8 @@
 # (ENV) BASE_URL - parent url, assuming binaries called jakartaeetck.zip, latest-glassfish.zip and payara-prerelease.zip
 # (ENV) TCK_URL - full url to TCK
 # (ENV) GLASSFISH_URL - full url to glassfish
-# (ENV) PAYARA_BUNDLE - full url to payara, or  a version to use maven to retrieve
+# (ENV) PAYARA_URL - full url to payara
+# (ENV) PAYARA_VERSION - version to use maven to retrieve - alternative to PAYARA_URL
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 . $SCRIPTPATH/functions.sh
@@ -116,7 +117,8 @@ export PROFILE=full
 export LANG="en_US.UTF-8"
 export GF_BUNDLE_URL=$GLASSFISH_URL
 export DATABASE=JavaDB
-export PAYARA_BUNDLE=$PAYARA_BUNDLE
+export GF_VI_BUNDLE_URL=$PAYARA_URL
+export PAYARA_VERSION=$PAYARA_VERSION
 export GF_VI_TOPLEVEL_DIR=payara5
 export DERBY_URL
 export EJBTIMER_DERBY_SQL


### PR DESCRIPTION
- originally it was possible to create a soflink to the built payara zip file  and forget it. TCK then simply used whatever was in the file.
- now it is possible to define PAYARA_VERSION env option and then scripts will ignore the soflitnk/file and use maven artifact instead.