### PR TITLE
QACI-409 Logging and debugging

### DIFF
--- a/client-logging.properties
+++ b/client-logging.properties
@@ -1,0 +1,12 @@
+handlers=java.util.logging.ConsoleHandler
+
+java.util.logging.ConsoleHandler.level=ALL
+
+.level=INFO
+javax.management.mbeanserver.level=INFO
+
+org.glassfish.grizzly.level=INFO
+ofg.glassfish.tyrus.level=INFO
+
+
+

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -109,10 +109,8 @@ cp ts.save $TS_HOME/bin/ts.jte
 
 export ADMIN_PASSWORD_FILE="${CTS_HOME}/admin-password.txt"
 echo "AS_ADMIN_PASSWORD=adminadmin" > ${ADMIN_PASSWORD_FILE}
-
 echo "AS_ADMIN_PASSWORD=" > ${CTS_HOME}/change-admin-password.txt
 echo "AS_ADMIN_NEWPASSWORD=adminadmin" >> ${CTS_HOME}/change-admin-password.txt
-
 echo "" >> ${CTS_HOME}/change-admin-password.txt
 
 installRI() {
@@ -232,8 +230,6 @@ if [ -z "${GF_VI_TOPLEVEL_DIR}" ]; then
     export GF_VI_TOPLEVEL_DIR=glassfish5
 fi
 
-
-
 if [[ -z "${PAYARA_VERSION}" ]]; then
     wget --progress=bar:force --no-cache $GF_VI_BUNDLE_URL -O ${CTS_HOME}/latest-glassfish-vi.zip
 else
@@ -275,7 +271,11 @@ if [[ $test_suite == ejb30/lite* ]] || [[ "ejb30" == $test_suite ]] ; then
   sed -i 's/-Xmx1024m/-Xmx4096m/g' ${TS_HOME}/bin/ts.jte
 fi 
 
-echo "AS_JAVA=$JAVA_HOME_VI" >> ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/config/asenv.conf
+echo "AS_JAVA=$JAVA_HOME_VI" >> ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/config/asenv.conf;
+if [ -n "${PAYARA_LOGGING_PROPERTIES}" ]; then
+  echo "Using logging configuration: ${PAYARA_LOGGING_PROPERTIES}";
+  cp "${PAYARA_LOGGING_PROPERTIES}" "${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/domains/domain1/config/logging.properties";
+fi
 
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${CTS_HOME}/change-admin-password.txt change-admin-password
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} start-domain
@@ -292,7 +292,8 @@ killjava "$JAVA_HOME_VI/bin/java"
 export CTS_ANT_OPTS="-Djava.endorsed.dirs=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/modules/endorsed \
 -Djavax.xml.accessExternalStylesheet=all \
 -Djavax.xml.accessExternalSchema=all \
--Djavax.xml.accessExternalDTD=file,http"
+-Djavax.xml.accessExternalDTD=file,http \
+"
 
 if [[ "$PROFILE" == "web" || "$PROFILE" == "WEB" ]];then
   KEYWORDS="javaee_web_profile|jacc_web_profile|jaspic_web_profile|javamail_web_profile|connector_web_profile"

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -276,6 +276,9 @@ if [ -n "${PAYARA_LOGGING_PROPERTIES}" ]; then
   echo "Using logging configuration: ${PAYARA_LOGGING_PROPERTIES}";
   cp "${PAYARA_LOGGING_PROPERTIES}" "${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/domains/domain1/config/logging.properties";
 fi
+if [[ -z "${HARNESS_DEBUG}" ]]; then
+  export HARNESS_DEBUG=false;
+fi
 
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${CTS_HOME}/change-admin-password.txt change-admin-password
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} start-domain
@@ -375,7 +378,8 @@ fi
 sed -i 's/^impl.deploy.timeout.multiplier=.*/impl.deploy.timeout.multiplier=240/g' ts.jte
 sed -i 's/^javatest.timeout.factor=.*/javatest.timeout.factor=2.0/g' ts.jte
 sed -i 's/^test.ejb.stateful.timeout.wait.seconds=.*/test.ejb.stateful.timeout.wait.seconds=180/g' ts.jte
-sed -i 's/^harness.log.traceflag=.*/harness.log.traceflag=false/g' ts.jte
+sed -i "s#^harness.log.traceflag=.*#harness.log.traceflag=${HARNESS_DEBUG}#g" ts.jte
+sed -i 's/^harness.maxoutputsize=.*/harness.maxoutputsize=10000000/g' ts.jte
 sed -i 's/^impl\.deploy\.timeout\.multiplier=240/impl\.deploy\.timeout\.multiplier=480/g' ts.jte
 
 if [ "servlet" == "${test_suite}" ]; then

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -57,6 +57,10 @@ echo "TS_HOME ${TS_HOME}"
 echo "PATH ${PATH}"
 echo "Test suite to run ${test_suite}"
 
+if [ -z "${CLIENT_LOGGING_PROPERTIES}" ]; then
+  export CLIENT_LOGGING_PROPERTIES="${WORKSPACE}/../../client-logging.properties";
+fi
+
 #Set default mailserver related env variables
 if [ -z "$MAIL_HOST" ]; then
   export MAIL_HOST="localhost"
@@ -381,6 +385,7 @@ sed -i 's/^test.ejb.stateful.timeout.wait.seconds=.*/test.ejb.stateful.timeout.w
 sed -i "s#^harness.log.traceflag=.*#harness.log.traceflag=${HARNESS_DEBUG}#g" ts.jte
 sed -i 's/^harness.maxoutputsize=.*/harness.maxoutputsize=10000000/g' ts.jte
 sed -i 's/^impl\.deploy\.timeout\.multiplier=240/impl\.deploy\.timeout\.multiplier=480/g' ts.jte
+sed -i "s#=client-logging\.properties#=${CLIENT_LOGGING_PROPERTIES}#g" ts.jte
 
 if [ "servlet" == "${test_suite}" ]; then
   sed -i 's/s1as\.java\.endorsed\.dirs=.*/s1as.java.endorsed.dirs=\$\{endorsed.dirs\}\$\{pathsep\}\$\{ts.home\}\/endorsedlib/g' ts.jte

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -280,6 +280,12 @@ if [ -n "${PAYARA_LOGGING_PROPERTIES}" ]; then
   echo "Using logging configuration: ${PAYARA_LOGGING_PROPERTIES}";
   cp "${PAYARA_LOGGING_PROPERTIES}" "${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/domains/domain1/config/logging.properties";
 fi
+if [[ -z "${PAYARA_DEBUG}" ]]; then
+  export PAYARA_DEBUG=false;
+fi
+if [ -z "${PAYARA_VERBOSE}" ]; then
+  export PAYARA_VERBOSE=false;
+fi
 if [[ -z "${HARNESS_DEBUG}" ]]; then
   export HARNESS_DEBUG=false;
 fi
@@ -339,6 +345,7 @@ export JT_WORK_DIR=${CTS_HOME}/jakartaeetck-work
 
 ### Update ts.jte for CTS run
 cd ${TS_HOME}/bin
+
 sed -i "s#^report.dir=.*#report.dir=${JT_REPORT_DIR}#g" ts.jte
 sed -i "s#^work.dir=.*#work.dir=${JT_WORK_DIR}#g" ts.jte
 
@@ -464,6 +471,22 @@ if [[ "securityapi" == ${test_suite} ]]; then
   echo "LDAP initilized for securityapi"
 fi
 
+### start PAYARA with arguments ###
+${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} set configs.config.server-config.java-config.debug-enabled=${PAYARA_DEBUG}
+${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} rotate-log
+${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} stop-domain
+${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} start-domain --debug=${PAYARA_DEBUG} --verbose=${PAYARA_VERBOSE} &
+
+# yield to allow to roll the file depending on logging configuration
+sleep 5;
+# Wait for the Payara Server [version] #badassfish startup message in server.log
+timeout 30 grep -q '\[NCLS\-CORE\-00017\]' <(tail -n 100000 -F "${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/domains/domain1/logs/server.log")
+
+if [[ "${PAYARA_DEBUG}" == "true" ]]; then
+  echo "********************************************************************************";
+  read -p "Attach the debugger to the Payara Server instance and hit ENTER";
+fi
+
 ### ctsStartStandardDeploymentServer.sh starts here #####
 cd $TS_HOME/bin;
 echo "ant start.auto.deployment.server > /tmp/deploy.out 2>&1 & "
@@ -476,14 +499,14 @@ if [ -z "$KEYWORDS" ]; then
     cd $TS_HOME/src/com/ibm/jbatch/tck;
     ant ${ANT_ARG} runclient -Dwork.dir=${JT_WORK_DIR}/jbatch -Dreport.dir=${JT_REPORT_DIR}/jbatch;
   else
-    ant ${ANT_ARG} -f xml/impl/payara/s1as.xml run.cts -Dant.opts="${CTS_ANT_OPTS} ${ANT_OPTS}" -Dtest.areas="${test_suite}"
+    ant ${ANT_ARG} -f xml/impl/payara/s1as.xml run.cts -Dant.opts="${CTS_ANT_OPTS} ${ANT_OPTS}" -Dtest.areas="${test_suite}" -Dskip.server.restart="true"
   fi
 else
   if [[ "jbatch" == ${test_suite} ]]; then
     cd $TS_HOME/src/com/ibm/jbatch/tck;
     ant ${ANT_ARG} runclient -Dkeywords=\"${KEYWORDS}\" -Dwork.dir=${JT_WORK_DIR}/jbatch -Dreport.dir=${JT_REPORT_DIR}/jbatch;
   else
-    ant ${ANT_ARG} -f xml/impl/payara/s1as.xml run.cts -Dkeywords=\"${KEYWORDS}\" -Dant.opts="${CTS_ANT_OPTS} ${ANT_OPTS}" -Dtest.areas="${test_suite}"
+    ant ${ANT_ARG} -f xml/impl/payara/s1as.xml run.cts -Dkeywords=\"${KEYWORDS}\" -Dant.opts="${CTS_ANT_OPTS} ${ANT_OPTS}" -Dtest.areas="${test_suite}" -Dskip.server.restart="true"
   fi
 fi
 

--- a/tck.sh
+++ b/tck.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Purpose of this file is to have better control over environment options on developer's system.
+# Uncomment and edit values as required.
+# Usage example (run websocket tests against Payara 5.2020.4):
+# ./tck.sh 5.2020.4 websocket
+
+export JAVA_HOME=/usr/lib/jvm/jdk1.8.0
+export ANT_HOME=/usr/share/ant
+
+# Ant and Java used for everything; maven is used from host's mvn command
+export PATH=$JAVA_HOME/bin:$ANT_HOME/bin/:$PATH
+
+# This payara version will be tested as vi (vendor implementation)
+export PAYARA_VERSION="$1"
+
+# This file will replace the configuration of the appserver
+#export PAYARA_LOGGING_PROPERTIES="$(pwd)/logging.properties"
+
+# Enable debugging of the Payara server under test
+# After everything is configured, the script asks user to connect the debugger and hit the ENTER key.
+# TCK tests then start and will pause on the first breakpoint
+#export PAYARA_DEBUG=true
+
+# log communication with the appserver in Ant configuration phase
+#export AS_DEBUG=true
+
+# Payara will start with --verbose, so stdout will be visible right in the output of this console
+# useful with the JVM debug output (ie with -verbose:class or -Djava.net.debug=all)
+#export PAYARA_VERBOSE=true
+
+# TCK will print what it does (at least something)
+#export HARNESS_DEBUG=true
+
+# TCK client logging.properties
+export CLIENT_LOGGING_PROPERTIES="$(pwd)/client-logging.properties"
+
+# Start the server if it is not started yet
+./bundles/run_server.sh || true &
+
+# Wait a second for the server startup
+sleep 1
+./run.sh $2 $3 $4 $5 $6
+

--- a/ts.override.properties
+++ b/ts.override.properties
@@ -34,11 +34,11 @@ tz=UTC
 
 # static shell needs AS_DERBY_INSTALL to locate derby classes properly
 command.testExecuteEjbEmbed=com.sun.ts.lib.harness.ExecTSTestCmd \
-        CLASSPATH=${ts.home}/lib/tsharness.jar${pathsep}\
-        ${ts.home}/lib/cts.jar${pathsep}\
-        ${ts.home}/lib/commons-lang3-3.3.2.jar${pathsep}\
-        ${jdbc.db.classes}${pathsep}\
-        ${javaee.home}/lib/embedded/glassfish-embedded-static-shell.jar \
+        CLASSPATH=${ts.home}/lib/tsharness.jar\
+${pathsep}${ts.home}/lib/cts.jar\
+${pathsep}${ts.home}/lib/commons-lang3-3.3.2.jar\
+${pathsep}${jdbc.db.classes}\
+${pathsep}${javaee.home}/lib/embedded/glassfish-embedded-static-shell.jar \
         DISPLAY=${ts.display} \
         HOME="${user.home}" \
         TMP=${TMP} \
@@ -69,7 +69,12 @@ command.testExecuteAppClient= \
         windir=${windir} \
         SYSTEMROOT=${SYSTEMROOT} \
         PATH="${javaee.home}/nativelib" \
-        APPCPATH=${ts.home}/lib/tsharness.jar${pathsep}${ts.home}/lib/cts.jar${pathsep}${javaee.home}/lib/jpa_alternate_provider.jar${pathsep}${ts.home}/lib/tssv.jar${pathsep}${javaee.home}/modules/weld-osgi-bundle.jar${pathsep}${javaee.home}/modules/cdi-api.jar \
+        APPCPATH=${ts.home}/lib/tsharness.jar\
+${pathsep}${ts.home}/lib/cts.jar\
+${pathsep}${javaee.home}/lib/jpa_alternate_provider.jar\
+${pathsep}${ts.home}/lib/tssv.jar\
+${pathsep}${javaee.home}/modules/weld-osgi-bundle.jar\
+${pathsep}${javaee.home}/modules/cdi-api.jar\
         TZ=${tz} \
         ${JAVA_HOME}/bin/java \
         -Xbootclasspath/p:${javaee.home}/modules/jakarta.annotation-api.jar \
@@ -106,53 +111,61 @@ command.testExecuteAppClient= \
         -Djava.util.logging.config.file=client-logging.properties \
         -javaagent:${javaee.home}/lib/gf-client.jar=arg=-configxml,arg=${ts.home}/tmp/appclient/s1as.sun-acc.xml,client=jar=$testExecuteArgs
 
-# Uncomment this for debugging standalone vehicle tests:
-#command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
-#        -v \
-#        CLASSPATH=${ts.harness.classpath}${pathsep}${ts.home}/classes${pathsep}\
-#        ${JAVA_HOME}/../lib/tools.jar${pathsep}\
-#        ${ri.modules}/security-ee.jar${pathsep}\
-#        ${ts.home}/lib/commons-httpclient-3.1.jar${pathsep}\
-#        ${ts.home}/lib/commons-logging-1.1.3.jar${pathsep}\
-#        ${ts.home}/lib/commons-codec-1.9.jar${pathsep}\
-#        ${ts.home}/lib/cssparser-0.9.25.jar${pathsep}\
-#        ${ts.home}/lib/htmlunit-2.15.jar${pathsep}\
-#        ${ts.home}/lib/htmlunit-core-js-2.15.jar${pathsep}\
-#        ${ts.home}/lib/httpcore-4.4.9.jar${pathsep}\
-#        ${ts.home}/lib/httpclient-4.5.5.jar${pathsep}\
-#        ${ts.home}/lib/httpmime-4.5.5.jar${pathsep}\
-#        ${ts.home}/lib/commons-collections-3.2.1.jar${pathsep}\
-#        ${ts.home}/lib/commons-io-2.4.jar${pathsep}\
-#        ${ts.home}/lib/commons-lang3-3.3.2.jar${pathsep}\
-#        ${ts.home}/lib/jaxen-1.1.6.jar${pathsep}\
-#        ${ts.home}/lib/nekohtml-1.9.21.jar${pathsep}\
-#        ${ts.home}/lib/sac-1.3.jar${pathsep}\
-#        ${ts.home}/lib/saxpath.jar${pathsep}\
-#        ${ts.home}/lib/xercesImpl-2.11.0.jar${pathsep}\
-#        ${ts.home}/lib/xalan-2.7.2.jar${pathsep}\
-#        ${ts.home}/lib/serializer-2.7.2.jar${pathsep}\
-#        ${ts.home}/lib/xml-apis-1.4.01.jar${pathsep}\
-#	${ts.home}/lib/unboundid-ldapsdk.jar${pathsep}\
-#        ${jdbc.db.classes} \
-#        DISPLAY=${ts.display} \
-#        HOME="${user.home}" \
-#        TMP=${TMP} \
-#        windir=${windir} \
-#        SYSTEMROOT=${SYSTEMROOT} \
-#        PATH="${javaee.home}/nativelib" \
-#        JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 \
-#        ${JAVA_HOME}/bin/java \
-#        -Dcts.tmp=$harness.temp.directory \
-#        -Djava.protocol.handler.pkgs=javax.net.ssl \
-#        -Djavax.net.ssl.keyStore=${bin.dir}/certificates/clientcert.jks \
-#        -Djavax.net.ssl.keyStorePassword=changeit \
-#        -Djavax.net.ssl.trustStore=${s1as.domain}/${sjsas.instance.config.dir}/cacerts.jks \
-#        -Djava.endorsed.dirs=${s1as.java.endorsed.dirs} \
-#        -Dcom.sun.aas.installRoot=${javaee.home} \
-#        -Dlog.file.location=${log.file.location} \
-#        -Dservlet.is.jsr115.compatible=${servlet.is.jsr115.compatible} \
-#        -Dprovider.configuration.file=${provider.configuration.file} \
-#        -Djava.security.properties=${s1as.domain}/${sjsas.instance.config.dir}/ts.java.security \
-#        -Dlogical.hostname.servlet=${logical.hostname.servlet} \
-#        -Dcom.sun.aas.configRoot=${javaee.home}/config \
-#        -Ddeliverable.class=${deliverable.class} $testExecuteClass $testExecuteArgs
+# This property is used to run tests
+# Useful options when you are stuck:
+# - change bootstrap classpath if the test side does something bad and you want to try some alternative, ie. -Xbootclasspath/p:/repo/git/grizzly/modules/http2/target/grizzly-http2-2.4.4.payara-p4-SNAPSHOT.jar${pathsep}/repo/git/grizzly/modules/grizzly/target/grizzly-framework-2.4.4.payara-p4-SNAPSHOT.jar
+# - log classloading -verbose:class
+# - log network communication with the server -Djavax.net.debug=all
+command.testExecute=\
+        com.sun.ts.lib.harness.ExecTSTestCmd \
+        CLASSPATH=${ts.harness.classpath}\
+${pathsep}${ts.home}/classes\
+${pathsep}${JAVA_HOME}/../lib/tools.jar\
+${pathsep}${ri.modules}/security-ee.jar\
+${pathsep}${ts.home}/lib/commons-httpclient-3.1.jar\
+${pathsep}${ts.home}/lib/commons-logging-1.1.3.jar\
+${pathsep}${ts.home}/lib/commons-codec-1.9.jar\
+${pathsep}${ts.home}/lib/cssparser-0.9.25.jar\
+${pathsep}${ts.home}/lib/htmlunit-2.15.jar\
+${pathsep}${ts.home}/lib/htmlunit-core-js-2.15.jar\
+${pathsep}${ts.home}/lib/httpcore-4.4.9.jar\
+${pathsep}${ts.home}/lib/httpclient-4.5.5.jar\
+${pathsep}${ts.home}/lib/httpmime-4.5.5.jar\
+${pathsep}${ts.home}/lib/commons-collections-3.2.1.jar\
+${pathsep}${ts.home}/lib/commons-io-2.4.jar\
+${pathsep}${ts.home}/lib/commons-lang3-3.3.2.jar\
+${pathsep}${ts.home}/lib/jaxen-1.1.6.jar\
+${pathsep}${ts.home}/lib/nekohtml-1.9.21.jar\
+${pathsep}${ts.home}/lib/sac-1.3.jar\
+${pathsep}${ts.home}/lib/saxpath.jar\
+${pathsep}${ts.home}/lib/xercesImpl-2.11.0.jar\
+${pathsep}${ts.home}/lib/xalan-2.7.2.jar\
+${pathsep}${ts.home}/lib/serializer-2.7.2.jar\
+${pathsep}${ts.home}/lib/xml-apis-1.4.01.jar\
+${pathsep}${ts.home}/lib/unboundid-ldapsdk.jar\
+${pathsep}${jdbc.db.classes} \
+        DISPLAY=${ts.display} \
+        HOME="${user.home}" \
+        TMP=${TMP} \
+        windir=${windir} \
+        SYSTEMROOT=${SYSTEMROOT} \
+        PATH="${javaee.home}/nativelib" \
+        ${JAVA_HOME}/bin/java \
+        -Xbootclasspath/p: \
+        -Dcts.tmp=$harness.temp.directory \
+        -Djava.protocol.handler.pkgs=javax.net.ssl \
+        -Djavax.net.ssl.keyStore=${bin.dir}/certificates/clientcert.jks \
+        -Djavax.net.ssl.keyStorePassword=changeit \
+        -Djavax.net.ssl.trustStore=${s1as.domain}/${sjsas.instance.config.dir}/cacerts.jks \
+        -Djava.endorsed.dirs=${s1as.java.endorsed.dirs} \
+        -Dcom.sun.aas.installRoot=${javaee.home} \
+        -Dlog.file.location=${log.file.location} \
+        -Dservlet.is.jsr115.compatible=${servlet.is.jsr115.compatible} \
+        -Dprovider.configuration.file=${provider.configuration.file} \
+        -Djava.security.properties=${s1as.domain}/${sjsas.instance.config.dir}/ts.java.security \
+        -Dlogical.hostname.servlet=${logical.hostname.servlet} \
+        -Dcom.sun.aas.configRoot=${javaee.home}/config \
+        -Djava.util.logging.config.file=client-logging.properties \
+        -Ddeliverable.class=${deliverable.class} \
+        $testExecuteClass $testExecuteArgs
+

--- a/ts.override.properties
+++ b/ts.override.properties
@@ -46,7 +46,7 @@ command.testExecuteEjbEmbed=com.sun.ts.lib.harness.ExecTSTestCmd \
         SYSTEMROOT=${SYSTEMROOT} \
         ${JAVA_HOME}/bin/java \
         -Dcts.tmp=$harness.temp.directory \
-        -Djava.util.logging.config.file=${javaee.home}/domains/domain1/config/logging.properties \
+        -Djava.util.logging.config.file=client-logging.properties \
         -DAS_DERBY_INSTALL=${javaee.home}/../javadb \
         -Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds} \
         -Djava.endorsed.dirs=${s1as.java.endorsed.dirs} \
@@ -102,8 +102,9 @@ command.testExecuteAppClient= \
         -Djava.security.properties=${s1as.domain}/${sjsas.instance.config.dir}/ts.java.security \
         -Djava.ext.dirs=${s1as.lib}/jdbcdrivers${pathsep}${JAVA_HOME}/lib/ext${pathsep}${JAVA_HOME}/jre/lib/ext${pathsep}${javaee.home}/lib/jdbcdrivers${pathsep}${javaee.home}/javadb/lib \
         -Dcom.sun.aas.configRoot=${javaee.home}/config \
-        -Ddeliverable.class=${deliverable.class} -javaagent:${javaee.home}/lib/gf-client.jar=arg=-configxml,arg=${ts.home}/tmp/appclient/s1as.sun-acc.xml,client=jar=$testExecuteArgs
-#        -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 
+        -Ddeliverable.class=${deliverable.class} \
+        -Djava.util.logging.config.file=client-logging.properties \
+        -javaagent:${javaee.home}/lib/gf-client.jar=arg=-configxml,arg=${ts.home}/tmp/appclient/s1as.sun-acc.xml,client=jar=$testExecuteArgs
 
 # Uncomment this for debugging standalone vehicle tests:
 #command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \


### PR DESCRIPTION
This PR improves capabilities to investigate causes of TCK failures

- to attach the debugger to the Payara Server instance
- to see verbose output of the appserver
- to configure logging of the appserver
- to configure logging of the TCK tests (JUL)
- to configure TCK logging
- to configure JVM of TCK tests

There are no changes for Jenkins, because all those things are enabled only when env variables are set. See tck.sh for a documented example.