### PR TITLE
Fix EAR and AppClient deployments for Jakarta EE 9

### DIFF
--- a/bundles/download.sh
+++ b/bundles/download.sh
@@ -1,5 +1,5 @@
 if [ ! -f jakartaeetck.zip ]; then
-  wget --read-timeout=20 https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9/promoted/jakartaeetck-9.0.0.zip -O jakartaeetck.zip
+  wget --read-timeout=20 https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9/promoted/jakartaeetck-9.1.0.zip -O jakartaeetck.zip
 fi
 if [ ! -f cdi-tck-3.0.2-dist.zip ]; then
   wget https://download.eclipse.org/ee4j/cdi/3.0/cdi-tck-3.0.1-dist.zip -O cdi-tck-3.0.2-dist.zip

--- a/bundles/run_server.sh
+++ b/bundles/run_server.sh
@@ -11,10 +11,10 @@ cd `dirname $0`
 check_present jakartaeetck.zip
 check_present latest-glassfish.zip
 check_present payara-prerelease.zip
-check_present cdi-tck-3.0.1-dist.zip
+check_present cdi-tck-3.0.2-dist.zip
 check_present bv-tck-3.0.0-dist.zip
-check_present jakarta.inject-tck-2.0.1-bin.zip
+check_present jakarta-inject-tck-2.0.1-bin.zip
 check_present javadb.zip
 check_present ejbtimer_derby.sql
 check_present jsr352-derby.sql
-exec python -m SimpleHTTPServer
+exec python3 -m http.server

--- a/cts-impl/common.xml
+++ b/cts-impl/common.xml
@@ -1637,4 +1637,19 @@ AS_ADMIN_NEWPASSWORD=${admin.password}</echo>
         <echo>******* DONE. ENABLE SECURE ADMIN ********</echo>
     </target>
 	
+    <!--
+      get.client.stubs retrieves the application JAR files needed to launch the application client..
+    -->
+    <target name="get.client.stubs" depends="configPlatform">
+       <exec executable="${exec.asadmin}" >
+           <arg line="${exec.asadmin.part2}" />
+           <arg line=" --user ${admin.user}"/>
+           <arg line=" --passwordfile ${password.file}"/>
+           <arg line=" --host ${server.host}"/>
+           <arg line=" --port ${server.port}"/>
+           <arg line=" get-client-stubs"/>
+           <arg line=" --appName ${deploy.app.name}"/>
+           <arg line=" ${get.stub.clients.ts_dep}"/>
+       </exec>
+    </target>   	 
 </project>

--- a/cts-impl/deploy.xml
+++ b/cts-impl/deploy.xml
@@ -17,10 +17,14 @@
 
 -->
 
-<project name="Glassfish Deployment" default="-deploy">
+<project name="Payara Deployment" default="-deploy">
 
     <!-- IMPORTS -->
     <import file="../../ts.common.props.xml" optional="true"/>
+
+    <!--<property name="deploy.dir" value="${deploy.dir}/"/>-->
+	<!-- Import to be used by stub generation and also includes common-->
+	<import file="./s1as.xml" optional="true"/>
 
     <!--<property name="deploy.dir" value="${deploy.dir}/"/>-->
 
@@ -34,29 +38,40 @@
     </presetdef>
 
     <!-- Deployment: DO NOT EDIT -->
-    <target name="-deploy">
+	<target name="-deploy">
 
-        <if>
-            <isset property="archive.file"/>
-            <then>
-                <fileset file="${archive.file}" id="deploy.archive.set"/>
-                <gf.echo message="Deploying:  ${archive.file}"/>
-            </then>
-        </if>
+		<if>
+			<isset property="archive.file"/>
+			<then>
+				<fileset file="${archive.file}" id="deploy.archive.set"/>
+				<gf.echo message="Deploying:  ${archive.file}"/>
+			</then>
+		</if>
 
-        <ts.glassfish.undeploy>
-            <fileset refid="deploy.archive.set"/>
-        </ts.glassfish.undeploy>
-        
-        <ts.add.sun.xml.to.component.archive> 
-            <fileset refid="deploy.archive.set"/>
-        </ts.add.sun.xml.to.component.archive>
-        
-        <ts.glassfish.deploy>
-            <fileset refid="deploy.archive.set"/>
-        </ts.glassfish.deploy>
-    </target>
-    
+		<ts.glassfish.undeploy>
+			<fileset refid="deploy.archive.set" />
+		</ts.glassfish.undeploy>
+
+		<ts.add.sun.xml.to.component.archive>
+			<fileset refid="deploy.archive.set" />
+		</ts.add.sun.xml.to.component.archive>
+
+		<ts.glassfish.deploy>
+			<fileset refid="deploy.archive.set"/>
+		</ts.glassfish.deploy>
+
+		<!-- Client stub generation-->
+		<if>
+			<isset property="get.stub.clients"/>
+    		<then>
+				 <antcall target="get.client.stubs">
+				 	<param name="deploy.app.name" value="${deploy.app.name}" />
+				 	<param name="get.stub.clients.ts_dep" value="${get.stub.clients.ts_dep}"/>
+				</antcall>
+			</then>
+		</if>
+	</target>
+
     <target name="-deploy.all">
         <ts.glassfish.undeploy> 
             <fileset refid="deploy.all.archive.set"/>

--- a/rerun.sh
+++ b/rerun.sh
@@ -113,16 +113,16 @@ fi
 if [ -z "$KEYWORDS" ]; then
   if [[ "jbatch" == ${test_suite} ]]; then
     cd $TS_HOME/src/com/ibm/jbatch/tck;
-    ant runclient $RUN_CLIENT_ARGS -Dwork.dir=${JT_WORK_DIR}/jbatch -Dreport.dir=${JT_REPORT_DIR}/jbatch |& tee -a $rerun_log
+    ant ${ANT_ARG} runclient -Dwork.dir=${JT_WORK_DIR}/jbatch -Dreport.dir=${JT_REPORT_DIR}/jbatch;
   else
-    ant -f xml/impl/glassfish/s1as.xml run.cts -Dant.opts="${CTS_ANT_OPTS} ${ANT_OPTS}" $RUN_CLIENT_ARGS  -DbuildJwsJaxws=false -Dtest.areas="${test_suite}" |& tee -a $rerun_log
+    ant ${ANT_ARG} -f xml/impl/payara/s1as.xml run.cts -Dant.opts="${CTS_ANT_OPTS} ${ANT_OPTS}" -Dtest.areas="${test_suite}"
   fi
 else
   if [[ "jbatch" == ${test_suite} ]]; then
     cd $TS_HOME/src/com/ibm/jbatch/tck;
-    ant runclient $RUN_CLIENT_ARGS -Dkeywords=\"${KEYWORDS}\" -Dwork.dir=${JT_WORK_DIR}/jbatch -Dreport.dir=${JT_REPORT_DIR}/jbatch |& tee -a $rerun_log
+    ant ${ANT_ARG} runclient -Dkeywords=\"${KEYWORDS}\" -Dwork.dir=${JT_WORK_DIR}/jbatch -Dreport.dir=${JT_REPORT_DIR}/jbatch;
   else
-    ant -f xml/impl/glassfish/s1as.xml run.cts -Dkeywords=\"${KEYWORDS}\" -Dant.opts="${CTS_ANT_OPTS} ${ANT_OPTS}" $RUN_CLIENT_ARGS  -DbuildJwsJaxws=false -Dtest.areas="${test_suite}" |& tee -a $rerun_log
+    ant ${ANT_ARG} -f xml/impl/payara/s1as.xml run.cts -Dkeywords=\"${KEYWORDS}\" -Dant.opts="${CTS_ANT_OPTS} ${ANT_OPTS}" -Dtest.areas="${test_suite}"
   fi
 fi
   # Generate combined report for both the runs.
@@ -131,7 +131,6 @@ if [[ "jbatch" == ${test_suite} ]]; then
 else  
   ant -Dreport.for=com/sun/ts/tests/$test_suite -Dreport.dir=${JT_REPORT_DIR}/${TEST_SUITE} -Dwork.dir=${JT_WORK_DIR}/${TEST_SUITE} report |& tee -a $rerun_log
 fi
-
 
 export HOST=`hostname -f`
 echo "1 ${TEST_SUITE} ${HOST}" > ${CTS_HOME}/args.txt


### PR DESCRIPTION
Client stubs need to be generated by Ant task, as support for JSR 88 API that would generate them has been removed from AutoDeployer implementation.

Scripts were updates with new versions and URLs, and `rerun.sh` was made functional again.