### PR TITLE
Fish 5672 run tck ee9 on payara6

### DIFF
--- a/bundles/download.sh
+++ b/bundles/download.sh
@@ -11,8 +11,8 @@ if [ ! -f bv-tck-3.0.0-dist.zip ]; then
 	wget https://download.eclipse.org/ee4j/bean-validation/3.0/beanvalidation-tck-dist-3.0.0.zip -O bv-tck-3.0.0-dist.zip
 fi
 if [ ! -f latest-glassfish.zip ]; then
-	wget https://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0.zip -O latest-glassfish.zip
+	wget https://download.eclipse.org/ee4j/glassfish/glassfish-6.2.4.zip -O latest-glassfish.zip
 fi
 if [ ! -f javadb.zip ]; then
-	wget https://dlcdn.apache.org//db/derby/db-derby-10.14.2.0/db-derby-10.14.2.0-bin.zip -O javadb.zip
+	wget https://dlcdn.apache.org//db/derby/db-derby-10.15.2.0/db-derby-10.15.2.0-bin.zip -O javadb.zip
 fi

--- a/client-logging.properties
+++ b/client-logging.properties
@@ -10,3 +10,4 @@ ofg.glassfish.tyrus.level=INFO
 
 
 
+javax.enterprise.system.core.security.com.sun.enterprise.security.ee=FINE

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -332,11 +332,16 @@ killjava "$JAVA_HOME_VI/bin/java"
 
 ##### configVI.sh starts here #####
 
-export CTS_ANT_OPTS="-Djava.endorsed.dirs=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/modules/endorsed \
--Djavax.xml.accessExternalStylesheet=all \
--Djavax.xml.accessExternalSchema=all \
--Djavax.xml.accessExternalDTD=file,http \
-"
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  export CTS_ANT_OPTS="-Djavax.xml.accessExternalStylesheet=all \
+                 -Djavax.xml.accessExternalSchema=all \
+     -Djavax.xml.accessExternalDTD=file,http"
+else
+  export CTS_ANT_OPTS="-Djava.endorsed.dirs=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/modules/endorsed \
+                 -Djavax.xml.accessExternalStylesheet=all \
+                 -Djavax.xml.accessExternalSchema=all \
+     -Djavax.xml.accessExternalDTD=file,http"
+fi
 
 if [[ "$PROFILE" == "web" || "$PROFILE" == "WEB" ]];then
   KEYWORDS="javaee_web_profile|jacc_web_profile|jaspic_web_profile|javamail_web_profile|connector_web_profile"

--- a/tck-jdk11.sh
+++ b/tck-jdk11.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Purpose of this file is to have better control over environment options on developer's system.
+# Uncomment and edit values as required.
+# Usage example (run websocket tests against Payara 5.2020.4):
+# ./tck.sh 5.2020.4 websocket
+
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+export ANT_HOME=/usr/share/ant
+export JDK=jdk11
+
+# Ant and Java used for everything; maven is used from host's mvn command
+export PATH=$JAVA_HOME/bin:$ANT_HOME/bin/:$PATH
+
+# This payara version will be tested as vi (vendor implementation)
+export PAYARA_VERSION="$1"
+
+# This file will replace the configuration of the appserver
+#export PAYARA_LOGGING_PROPERTIES="$(pwd)/logging.properties"
+
+# Enable debugging of the Payara server under test
+# After everything is configured, the script asks user to connect the debugger and hit the ENTER key.
+# TCK tests then start and will pause on the first breakpoint
+#export PAYARA_DEBUG=true
+
+# log communication with the appserver in Ant configuration phase
+#export AS_DEBUG=true
+
+# Payara will start with --verbose, so stdout will be visible right in the output of this console
+# useful with the JVM debug output (ie with -verbose:class or -Djava.net.debug=all)
+#export PAYARA_VERBOSE=true
+
+# TCK will print what it does (at least something)
+#export HARNESS_DEBUG=true
+
+# TCK client logging.properties
+export CLIENT_LOGGING_PROPERTIES="$(pwd)/client-logging.properties"
+
+# Start the server if it is not started yet
+./bundles/run_server.sh || true &
+
+# Wait a second for the server startup
+sleep 1
+./run.sh $2 $3 $4 $5 $6
+

--- a/ts.override.properties
+++ b/ts.override.properties
@@ -54,6 +54,7 @@ command.testExecuteEjbEmbed=com.sun.ts.lib.harness.ExecTSTestCmd \
 
 # disable variable substitution in TCK tests, set UTC timezone
 vi.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Xmx4095m:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds}:-DwebServerPort.2=${webServerPort.2}:-DwebServerHost.2=${webServerHost.2}:-Dcsiv2.save.log.file=${harness.log.traceflag}:-Djavax.xml.accessExternalStylesheet=all:-Djavax.xml.accessExternalDTD=file,http:-Dfish.payara.substitution.disable=true:-Duser.timezone=UTC
+#:-Dcom.sun.enterprise.security.provider.PolicyWrapper.force_app_refresh=true:-Djava.security.debug=failure
 vi.jvm.options.remove=-Xmx512m:${vi.jvm.options}
 
 # set UTC also for RI

--- a/watch.sh
+++ b/watch.sh
@@ -15,5 +15,5 @@
 
 FILE=`ls -td cts_home/* | head -1`
 echo Watching $FILE
-tail -f $FILE | grep "Number of"
+tail -n 500000 -f $FILE | grep "Number of"
 


### PR DESCRIPTION
Updating scripts for jdk11, removing setup of endorsing dir.

Use tck-jdk11.sh for running the tck on Java 11.
