### PR TITLE
FISH-6441 Fix GlassFish Path

### DIFF
--- a/cts-impl/install_sjsas.xml
+++ b/cts-impl/install_sjsas.xml
@@ -782,7 +782,7 @@ The following facts makes it hard to maintain and generalize:
            Change this prop name once the GF 4 bundle updates the base dir of the bundle.
            The javaee.home.ri prop value in ts.jte should also be updated to glassfish4.
        -->
-          <property name="v4.install.path" value="glassfish6"/>
+          <property name="v4.install.path" value="glassfish7"/>
       
         <propertyregex property="v4.install.dir.norm"
                        input="${v4.install.dir}"

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -51,13 +51,13 @@ fi
 export TS_HOME=${CTS_HOME}/jakartaeetck/
 
 if [ -z "${GF_RI_TOPLEVEL_DIR}" ]; then
-    echo "Using glassfish6 for GF_RI_TOPLEVEL_DIR"
-    export GF_RI_TOPLEVEL_DIR=glassfish6
+    echo "Using glassfish7 for GF_RI_TOPLEVEL_DIR"
+    export GF_RI_TOPLEVEL_DIR=glassfish7
 fi
 
 if [ -z "${GF_VI_TOPLEVEL_DIR}" ]; then
-    echo "Using glassfish6 for GF_VI_TOPLEVEL_DIR"
-    export GF_VI_TOPLEVEL_DIR=glassfish6
+    echo "Using glassfish7 for GF_VI_TOPLEVEL_DIR"
+    export GF_VI_TOPLEVEL_DIR=glassfish7
 fi
 
 if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
@@ -254,8 +254,8 @@ if [ -z "${GF_VI_BUNDLE_URL}" ]; then
 fi
 
 if [ -z "${GF_VI_TOPLEVEL_DIR}" ]; then
-    echo "Using glassfish6 for GF_VI_TOPLEVEL_DIR"
-    export GF_VI_TOPLEVEL_DIR=glassfish6
+    echo "Using glassfish7 for GF_VI_TOPLEVEL_DIR"
+    export GF_VI_TOPLEVEL_DIR=glassfish7
 fi
 
 if [[ -z "${PAYARA_VERSION}" ]]; then

--- a/patch/run_jakartaeetck.sh
+++ b/patch/run_jakartaeetck.sh
@@ -42,13 +42,13 @@ fi
 export TS_HOME=${CTS_HOME}/jakartaeetck/
 
 if [ -z "${GF_RI_TOPLEVEL_DIR}" ]; then
-    echo "Using glassfish6 for GF_RI_TOPLEVEL_DIR"
-    export GF_RI_TOPLEVEL_DIR=glassfish6
+    echo "Using glassfish7 for GF_RI_TOPLEVEL_DIR"
+    export GF_RI_TOPLEVEL_DIR=glassfish7
 fi
 
 if [ -z "${GF_VI_TOPLEVEL_DIR}" ]; then
-    echo "Using glassfish6 for GF_VI_TOPLEVEL_DIR"
-    export GF_VI_TOPLEVEL_DIR=glassfish6
+    echo "Using glassfish7 for GF_VI_TOPLEVEL_DIR"
+    export GF_VI_TOPLEVEL_DIR=glassfish7
 fi
 
 if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then


### PR DESCRIPTION
A couple of the webservices tests seem to require GlassFish for generating the wsdl clients - this fixes the path.