### PR TITLE
Fish 6488 adding condition for jdk17

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -12,7 +12,7 @@
 # https://www.gnu.org/software/classpath/license.html.
 #
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-
+echo "Applying overrrides"
 apply_overrides () {
     if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
         OVERRIDE_PROP=ts.override.jdk11.properties

--- a/functions.sh
+++ b/functions.sh
@@ -16,6 +16,8 @@
 apply_overrides () {
     if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
         OVERRIDE_PROP=ts.override.jdk11.properties
+    elif [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
+        OVERRIDE_PROP=ts.override.jdk17.properties
     else
         OVERRIDE_PROP=ts.override.properties
     fi

--- a/functions.sh
+++ b/functions.sh
@@ -12,11 +12,11 @@
 # https://www.gnu.org/software/classpath/license.html.
 #
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-echo "Applying overrrides"
+
 apply_overrides () {
-    if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+    if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]]; then
         OVERRIDE_PROP=ts.override.jdk11.properties
-    elif [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
+    elif [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]]; then
         OVERRIDE_PROP=ts.override.jdk17.properties
     else
         OVERRIDE_PROP=ts.override.properties

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -62,6 +62,7 @@ if [ -z "${GF_VI_TOPLEVEL_DIR}" ]; then
 fi
 
 if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]]; then
+  export JAVA_HOME=${JDK11_HOME}
   export PATH=$JAVA_HOME/bin:$PATH
   export ANT_OPTS="-Xmx2G \
                  -Djavax.xml.accessExternalStylesheet=all \
@@ -72,6 +73,7 @@ if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]]; then
                  -Djavax.xml.accessExternalSchema=all \
      -Djavax.xml.accessExternalDTD=file,http"
 elif [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]]; then
+  export JAVA_HOME=${JDK17_HOME}
   export PATH=$JAVA_HOME/bin:$PATH
   export ANT_OPTS="-Xmx2G \
                   -Djavax.xml.accessExternalStylesheet=all \

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -72,7 +72,17 @@ if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
   export CTS_ANT_OPTS="-Djavax.xml.accessExternalStylesheet=all \
                  -Djavax.xml.accessExternalSchema=all \
      -Djavax.xml.accessExternalDTD=file,http"
-
+elif [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
+  export JAVA_HOME=${JDK17_HOME}
+  export PATH=$JAVA_HOME/bin:$PATH
+  export ANT_OPTS="-Xmx2G \
+                  -Djavax.xml.accessExternalStylesheet=all \
+                  -Djavax.xml.accessExternalSchema=all \
+  	 -DenableExternalEntityProcessing=true \
+                   -Djavax.xml.accessExternalDTD=file,http"
+  export CTS_ANT_OPTS="-Djavax.xml.accessExternalStylesheet=all \
+                 -Djavax.xml.accessExternalSchema=all \
+      -Djavax.xml.accessExternalDTD=file,http"
 else
   export ANT_OPTS="-Xmx2G -Djava.endorsed.dirs=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/modules/endorsed \
                  -Djavax.xml.accessExternalStylesheet=all \
@@ -333,6 +343,10 @@ if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
   export CTS_ANT_OPTS="-Djavax.xml.accessExternalStylesheet=all \
                  -Djavax.xml.accessExternalSchema=all \
      -Djavax.xml.accessExternalDTD=file,http"
+elif [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]]; then
+  export CTS_ANT_OPTS="-Djavax.xml.accessExternalStylesheet=all \
+                   -Djavax.xml.accessExternalSchema=all \
+       -Djavax.xml.accessExternalDTD=file,http"
 else
   export CTS_ANT_OPTS="-Djava.endorsed.dirs=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/modules/endorsed \
                  -Djavax.xml.accessExternalStylesheet=all \

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -95,11 +95,11 @@ else
      -Djavax.xml.accessExternalDTD=file,http"
 
 fi
-
+echo "Current Java_HOME: ${JAVA_HOME}"
 if [ -z "${RI_JAVA_HOME}" ]; then
   export RI_JAVA_HOME=$JAVA_HOME
 fi
-
+echo "Current Java_HOME: ${JAVA_HOME}"
 # Run CTS related steps
 echo "JAVA_HOME ${JAVA_HOME}"
 echo "ANT_HOME ${ANT_HOME}"

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -61,8 +61,7 @@ if [ -z "${GF_VI_TOPLEVEL_DIR}" ]; then
     export GF_VI_TOPLEVEL_DIR=glassfish7
 fi
 
-if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
-  export JAVA_HOME=${JDK11_HOME}
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]]; then
   export PATH=$JAVA_HOME/bin:$PATH
   export ANT_OPTS="-Xmx2G \
                  -Djavax.xml.accessExternalStylesheet=all \
@@ -72,8 +71,7 @@ if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
   export CTS_ANT_OPTS="-Djavax.xml.accessExternalStylesheet=all \
                  -Djavax.xml.accessExternalSchema=all \
      -Djavax.xml.accessExternalDTD=file,http"
-elif [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
+elif [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]]; then
   export PATH=$JAVA_HOME/bin:$PATH
   export ANT_OPTS="-Xmx2G \
                   -Djavax.xml.accessExternalStylesheet=all \
@@ -95,11 +93,11 @@ else
      -Djavax.xml.accessExternalDTD=file,http"
 
 fi
-echo "Current Java_HOME: ${JAVA_HOME}"
+
 if [ -z "${RI_JAVA_HOME}" ]; then
   export RI_JAVA_HOME=$JAVA_HOME
 fi
-echo "Current Java_HOME: ${JAVA_HOME}"
+
 # Run CTS related steps
 echo "JAVA_HOME ${JAVA_HOME}"
 echo "ANT_HOME ${ANT_HOME}"
@@ -339,7 +337,7 @@ killjava "$JAVA_HOME_VI/bin/java"
 
 ##### configVI.sh starts here #####
 
-if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]]; then
   export CTS_ANT_OPTS="-Djavax.xml.accessExternalStylesheet=all \
                  -Djavax.xml.accessExternalSchema=all \
      -Djavax.xml.accessExternalDTD=file,http"

--- a/run.sh
+++ b/run.sh
@@ -55,7 +55,6 @@ pkill -KILL -f glassfish
 if [ -z "$JAVA_HOME" ]; then
   export JAVA_HOME=`readlink -f /usr/bin/java | sed  "s:\(/jre\)\?/bin/java::"`
 fi
-echo "Current Java_HOME: ${JAVA_HOME}"
 if [ -z "$SKIP_TCK" ]; then
     # clean cts directory
     rm -rf $CTS_HOME/*
@@ -74,7 +73,6 @@ if [ -z "$SKIP_TCK" ]; then
       cp patch/run_jakartaeetck.sh $WORKSPACE/docker/
     fi;
 fi
-echo "Current Java_HOME: ${JAVA_HOME}"
 # link VI impl
 rm -rf $WORKSPACE/bin/xml/impl/payara
 ln -s $SCRIPTPATH/cts-impl $WORKSPACE/bin/xml/impl/payara
@@ -113,7 +111,7 @@ export GF_VI_TOPLEVEL_DIR=payara6
 export DERBY_URL
 export EJBTIMER_DERBY_SQL
 export JSR352_DERBY_SQL
-echo "Current Java_HOME: ${JAVA_HOME}"
+
 TEST_SUITE=`echo "$1" | tr '/' '_'`
 
 # (ENV) SKIP_TEST - if just testing the script

--- a/run.sh
+++ b/run.sh
@@ -55,7 +55,7 @@ pkill -KILL -f glassfish
 if [ -z "$JAVA_HOME" ]; then
   export JAVA_HOME=`readlink -f /usr/bin/java | sed  "s:\(/jre\)\?/bin/java::"`
 fi
-
+echo "Current Java_HOME: ${JAVA_HOME}"
 if [ -z "$SKIP_TCK" ]; then
     # clean cts directory
     rm -rf $CTS_HOME/*
@@ -74,7 +74,7 @@ if [ -z "$SKIP_TCK" ]; then
       cp patch/run_jakartaeetck.sh $WORKSPACE/docker/
     fi;
 fi
-
+echo "Current Java_HOME: ${JAVA_HOME}"
 # link VI impl
 rm -rf $WORKSPACE/bin/xml/impl/payara
 ln -s $SCRIPTPATH/cts-impl $WORKSPACE/bin/xml/impl/payara
@@ -113,7 +113,7 @@ export GF_VI_TOPLEVEL_DIR=payara6
 export DERBY_URL
 export EJBTIMER_DERBY_SQL
 export JSR352_DERBY_SQL
-
+echo "Current Java_HOME: ${JAVA_HOME}"
 TEST_SUITE=`echo "$1" | tr '/' '_'`
 
 # (ENV) SKIP_TEST - if just testing the script

--- a/ts.override.jdk17.properties
+++ b/ts.override.jdk17.properties
@@ -1,0 +1,203 @@
+#
+# Copyright (c) 2019, 2022 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+# Use own CTS Impl
+impl.vi=payara
+# Authconfig factory was renamed in Payara 5
+vendor.authconfig.factory=com.sun.enterprise.security.jaspic.config.GFAuthConfigFactory
+# Separate RI and VI databases
+# derby.port.ri=1529
+
+wsgen.ant.classname=com.sun.tools.ws.WsGen
+wsimport.ant.classname=com.sun.tools.ws.WsImport
+
+# API classes present in Payara. There's no endorsed directory compared to glassfish
+javaee.classes=${s1as.modules}/jakarta.jms-api.jar${pathsep}${s1as.modules}/jakarta.json.jar${pathsep}${s1as.modules}/parsson-media.jar${pathsep}${s1as.modules}/jakarta.json.bind-api.jar${pathsep}${s1as.modules}/jakarta.ejb-api.jar${pathsep}${s1as.modules}/jakarta.annotation-api.jar${pathsep}${s1as.modules}/jakarta.enterprise.deploy-api.jar${pathsep}${s1as.modules}/jakarta.persistence.jar${pathsep}${s1as.modules}/jakarta.resource-api.jar${pathsep}${s1as.modules}/jakarta.security.auth.message-api.jar${pathsep}${s1as.modules}/jakarta.security.jacc-api.jar${pathsep}${s1as.modules}/jakarta.servlet-api.jar${pathsep}${s1as.modules}/el-impl.jar${pathsep}${s1as.modules}/jakarta.servlet.jsp-api.jar${pathsep}${jtaJarClasspath}${pathsep}${s1as.modules}/jakarta.xml.bind-api.jar${pathsep}${s1as.modules}/jaxb-osgi.jar${pathsep}${s1as.modules}/jmxremote_optional-repackaged.jar${pathsep}${s1as.modules}/jakarta.faces.jar${pathsep}${s1as.modules}/jakarta.servlet.jsp.jstl.jar${pathsep}${ri.modules}/jakarta.servlet.jsp.jstl-api.jar${pathsep}${s1as.modules}/webservices-osgi.jar${pathsep}${s1as.modules}/webservices-api-osgi.jar${pathsep}${s1as.modules}/jakarta.management.j2ee-api.jar${pathsep}${s1as.modules}/ejb.security.jar${pathsep}${s1as.modules}/glassfish-corba-csiv2-idl.jar${pathsep}${s1as.modules}/weld-osgi-bundle.jar${pathsep}${implementation.classes}${pathsep}${s1as.modules}/javamail-connector.jar${pathsep}${s1as.modules}/javamail-runtime.jar${pathsep}${s1as.modules}/jakarta.websocket-api.jar${pathsep}${s1as.modules}/jakarta.enterprise.concurrent-api.jar${pathsep}${s1as.modules}/jakarta.batch-api.jar${pathsep}${s1as.modules}/jakarta.enterprise.cdi-api.jar$${pathsep}${s1as.modules}/jakarta.xml.ws-api.jar${pathsep}${s1as.modules}/jakarta.xml.bind-api.jar${pathsep}${s1as.modules}/jakarta.authentication-api.jar${pathsep}${s1as.modules}/jakarta.authorization-api.jar
+
+# API implementations and their dependencies
+implementation.classes=${s1as.modules}/deployment-client.jar${pathsep}${s1as.modules}/security.jar${pathsep}${s1as.modules}/common-util.jar${pathsep}${s1as.modules}/glassfish-corba-omgapi.jar${pathsep}${s1as.modules}/deployment-common.jar${pathsep}${s1as.modules}/gmbal.jar${pathsep}${s1as.modules}/hibernate-validator.jar${pathsep}${s1as.modules}/jakarta.ws.rs-api.jar${pathsep}${s1as.modules}/jersey-client.jar${pathsep}${s1as.modules}/jersey-common.jar${pathsep}${s1as.modules}/jersey-hk2.jar${pathsep}${s1as.modules}/jersey-media-jaxb.jar${pathsep}${s1as.modules}/jersey-media-sse.jar${pathsep}${s1as.modules}/jersey-media-json-processing.jar${pathsep}${s1as.modules}/parsson-media.jar${pathsep}${s1as.modules}/jersey-media-json-binding.jar${pathsep}${s1as.modules}/jersey-server.jar${pathsep}${s1as.modules}/jersey-container-servlet.jar${pathsep}${s1as.modules}/jersey-container-servlet-core.jar${pathsep}${s1as.modules}/guava.jar${pathsep}${s1as.modules}/jakarta.websocket-client-api.jar${pathsep}${s1as.modules}/tyrus-client.jar${pathsep}${s1as.modules}/tyrus-core.jar${pathsep}${s1as.modules}/tyrus-container-grizzly.jar${pathsep}${s1as.modules}/tyrus-container-grizzly-client.jar${pathsep}${s1as.modules}/glassfish-grizzly-extra-all.jar${pathsep}${s1as.modules}/nucleus-grizzly-all.jar${pathsep}${s1as.modules}/tyrus-server.jar${pathsep}${s1as.modules}/tyrus-container-servlet.jar${pathsep}${s1as.modules}/tyrus-spi.jar${pathsep}${s1as.modules}/payara-jbatch.jar${pathsep}${pathsep}${s1as.modules}/glassfish-batch-connector.jar${pathsep}${s1as.modules}/glassfish-batch-commands.jar${pathsep}${s1as.modules}/yasson.jar
+
+# API classes for signature test. Now should be matching GlassFish's
+sigTestClasspath=${s1as.modules}/glassfish-corba-omgapi.jar${pathsep}${s1as.modules}/glassfish-corba-orb.jar${pathsep}${s1as.modules}/jakarta.enterprise.cdi-api.jar${pathsep}${s1as.modules}/jakarta.json.jar${pathsep}${s1as.modules}/jakarta.json.bind-api.jar${pathsep}${s1as.modules}/jakarta.batch-api.jar${pathsep}${s1as.modules}/jakarta.interceptor-api.jar${pathsep}${s1as.modules}/stax2-api.jar${pathsep}${s1as.modules}/jakarta.enterprise.concurrent-api.jar${pathsep}${s1as.modules}/jakarta.websocket-api.jar${pathsep}${s1as.modules}/jakarta.websocket-client-api.jar${pathsep}${s1as.modules}/jakarta.jms-api.jar${pathsep}${s1as.modules}/jakarta.faces.jar${pathsep}${s1as.modules}/jakarta.validation-api.jar${pathsep}${s1as.modules}/jakarta.annotation-api.jar${pathsep}${s1as.modules}/jakarta.xml.bind-api.jar${pathsep}${s1as.modules}/webservices-api-osgi.jar${pathsep}${s1as.modules}/jakarta.ws.rs-api.jar${pathsep}${s1as.modules}/weld-osgi-bundle.jar${pathsep}${s1as.modules}/jakarta.ejb-api.jar${pathsep}${s1as.modules}/jakarta.mail-api.jar${pathsep}${s1as.modules}/jakarta.persistence-api.jar${pathsep}${s1as.modules}/jakarta.resource-api.jar${pathsep}${s1as.modules}/jakarta.authorization-api.jar${pathsep}${s1as.modules}/jakarta.authentication-api.jar${pathsep}${s1as.modules}/jakarta.servlet-api.jar${pathsep}${s1as.modules}/jakarta.inject-api.jar${pathsep}${s1as.modules}/jakarta.el-api.jar${pathsep}${s1as.modules}/jakarta.servlet.jsp-api.jar${pathsep}${s1as.modules}/jakarta.servlet.jsp.jstl-api.jar${pathsep}${jtaJarClasspath}${pathsep}${s1as.modules}/jakarta.security.enterprise-api.jar${pathsep}${s1as.modules}/jakarta.activation-api.jar${pathsep}${jimage.dir}/java.base${pathsep}${jimage.dir}/java.rmi${pathsep}${jimage.dir}/java.sql${pathsep}${jimage.dir}/java.naming
+
+# Match VM timezone (also set your OS to UTC!)
+tz=UTC
+
+# static shell needs AS_DERBY_INSTALL to locate derby classes properly
+command.testExecuteEjbEmbed=com.sun.ts.lib.harness.ExecTSTestCmd \
+        CLASSPATH=${ts.home}/lib/tsharness.jar${pathsep}\
+        ${ts.home}/lib/cts.jar${pathsep}\
+        ${ts.home}/lib/glassfishporting.jar${pathsep}\
+        ${ts.home}/lib/commons-lang3-3.3.2.jar${pathsep}\
+        ${jdbc.db.classes}${pathsep}\
+        ${javaee.home}/lib/embedded/glassfish-embedded-static-shell.jar \
+        DISPLAY=${ts.display} \
+        HOME="${user.home}" \
+        TMP=${TMP} \
+        windir=${windir} \
+        SYSTEMROOT=${SYSTEMROOT} \
+        ${JAVA_HOME}/bin/java \
+        -Dcts.tmp=$harness.temp.directory \
+        -Djava.util.logging.config.file=${javaee.home}/domains/domain1/config/logging.properties \
+        -DAS_DERBY_INSTALL=${javaee.home}/../javadb \
+        -Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds} \
+        -Ddeliverable.class=${deliverable.class} $testExecuteClass $testExecuteArgs
+
+# disable variable substitution in TCK tests, set UTC timezone
+vi.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Xmx4095m:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds}:-DwebServerPort.2=${webServerPort.2}:-DwebServerHost.2=${webServerHost.2}:-Dcsiv2.save.log.file=${harness.log.traceflag}:-Djavax.xml.accessExternalStylesheet=all:-Djavax.xml.accessExternalDTD=file,http:-Dfish.payara.substitution.disable=true:-Duser.timezone=UTC:--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED
+vi.jvm.options.remove=-Xmx512m:${vi.jvm.options}
+
+# set UTC also for RI
+ri.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Xmx4096m:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds}:-DwebServerPort.2=${webServerPort.2}:-DwebServerHost.2=${webServerHost.2}:-Dcsiv2.save.log.file=${harness.log.traceflag}:-Djavax.xml.accessExternalStylesheet=all:-Djavax.xml.accessExternalDTD=file,http:-Duser.timezone=UTC
+
+
+# Common Annotations need to be put on bootclasspath
+command.testExecuteAppClient= \
+        com.sun.ts.lib.harness.ExecTSTestCmd DISPLAY=${ts.display} HOME="${user.home}" \
+        LD_LIBRARY_PATH=${javaee.home}/lib \
+        TMP=${TMP} \
+        windir=${windir} \
+        SYSTEMROOT=${SYSTEMROOT} \
+        PATH="${javaee.home}/nativelib" \
+        APPCPATH=${ts.home}/lib/tsharness.jar${pathsep}${ts.home}/lib/cts.jar${pathsep}${ts.home}/lib/glassfishporting.jar${pathsep}${javaee.home}/lib/jpa_alternate_provider.jar${pathsep}${ts.home}/lib/tssv.jar${pathsep}${javaee.home}/modules/weld-osgi-bundle.jar${pathsep}${javaee.home}/modules/jakarta.enterprise.cdi-api.jar \
+        TZ=${tz} \
+        ${JAVA_HOME}/bin/java \
+        -Djava.system.class.loader=org.glassfish.appclient.client.acc.agent.ACCAgentClassLoader  \
+        -Djava.security.policy=${javaee.home}/lib/appclient/client.policy \
+        -Dcts.tmp=$harness.temp.directory \
+        -Djava.security.auth.login.config=${javaee.home}/lib/appclient/appclientlogin.conf \
+        -Djava.protocol.handler.pkgs=javax.net.ssl \
+        -Dcom.sun.enterprise.home=${javaee.home} \
+        -Djavax.net.ssl.keyStore=${bin.dir}/certificates/clientcert.jks \
+        -Djavax.net.ssl.keyStorePassword=changeit \
+        -Dcom.sun.aas.installRoot=${javaee.home} \
+        -Dcom.sun.aas.imqLib=${javaee.home}/../mq/lib \
+        -Djavax.net.ssl.trustStore=${s1as.domain}/${sjsas.instance.config.dir}/cacerts.jks \
+        -Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl \
+        -Djavax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl \
+        -Djavax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl \
+        -Dorg.xml.sax.driver=com.sun.org.apache.xerces.internal.parsers.SAXParser \
+        -Dorg.xml.sax.parser=org.xml.sax.helpers.XMLReaderAdapter \
+        -Doracle.jdbc.J2EE13Compliant=true \
+        -Doracle.jdbc.mapDateToTimestamp -Djava.security.manager \
+        -Dstartup.login=false \
+        -Dauth.gui=false \
+        -Dlog.file.location=${log.file.location} \
+        -Dri.log.file.location=${ri.log.file.location} \
+        -DwebServerHost.2=${webServerHost.2} \
+        -DwebServerPort.2=${webServerPort.2} \
+        -Dprovider.configuration.file=${provider.configuration.file} \
+        -Djava.security.properties=${s1as.domain}/${sjsas.instance.config.dir}/ts.java.security \
+        -Dcom.sun.aas.configRoot=${javaee.home}/config \
+        -Ddeliverable.class=${deliverable.class} -javaagent:${javaee.home}/lib/gf-client.jar=arg=-configxml,arg=${ts.home}/tmp/appclient/s1as.sun-acc.xml,client=jar=$testExecuteArgs
+#        -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 
+
+command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
+        CLASSPATH=${ts.harness.classpath}${pathsep}${ts.home}/classes${pathsep}\
+        ${JAVA_HOME}/../lib/tools.jar${pathsep}\
+        ${s1as.modules}/security-ee.jar${pathsep}\
+        ${ts.home}/lib/commons-httpclient-3.1.jar${pathsep}\
+        ${ts.home}/lib/commons-logging-1.1.3.jar${pathsep}\
+        ${ts.home}/lib/commons-codec-1.9.jar${pathsep}\
+        ${ts.home}/lib/cssparser-0.9.25.jar${pathsep}\
+        ${ts.home}/lib/htmlunit-2.15.jar${pathsep}\
+        ${ts.home}/lib/htmlunit-core-js-2.15.jar${pathsep}\
+        ${ts.home}/lib/httpcore-4.4.9.jar${pathsep}\
+        ${ts.home}/lib/httpclient-4.5.5.jar${pathsep}\
+        ${ts.home}/lib/httpmime-4.5.5.jar${pathsep}\
+        ${ts.home}/lib/commons-collections-3.2.1.jar${pathsep}\
+        ${ts.home}/lib/commons-io-2.4.jar${pathsep}\
+        ${ts.home}/lib/commons-lang3-3.3.2.jar${pathsep}\
+        ${ts.home}/lib/jaxen-1.1.6.jar${pathsep}\
+        ${ts.home}/lib/nekohtml-1.9.21.jar${pathsep}\
+        ${ts.home}/lib/sac-1.3.jar${pathsep}\
+        ${ts.home}/lib/saxpath.jar${pathsep}\
+        ${ts.home}/lib/xercesImpl-2.11.0.jar${pathsep}\
+        ${ts.home}/lib/xalan-2.7.2.jar${pathsep}\
+        ${ts.home}/lib/serializer-2.7.2.jar${pathsep}\
+        ${ts.home}/lib/xml-apis-1.4.01.jar${pathsep}\
+	${ts.home}/lib/unboundid-ldapsdk.jar${pathsep}\
+        ${jdbc.db.classes} \
+        DISPLAY=${ts.display} \
+        HOME="${user.home}" \
+        TMP=${TMP} \
+        windir=${windir} \
+        SYSTEMROOT=${SYSTEMROOT} \
+        PATH="${javaee.home}/nativelib" \
+        ${JAVA_HOME}/bin/java \
+        -Dcts.tmp=$harness.temp.directory \
+        -Djava.protocol.handler.pkgs=javax.net.ssl \
+        -Djavax.net.ssl.keyStore=${bin.dir}/certificates/clientcert.jks \
+        -Djavax.net.ssl.keyStorePassword=changeit \
+        -Djavax.net.ssl.trustStore=${s1as.domain}/${sjsas.instance.config.dir}/cacerts.jks \
+        -Dcom.sun.aas.installRoot=${javaee.home} \
+        -Dlog.file.location=${log.file.location} \
+        -Dservlet.is.jsr115.compatible=${servlet.is.jsr115.compatible} \
+        -Dprovider.configuration.file=${provider.configuration.file} \
+        -Djava.security.properties=${s1as.domain}/${sjsas.instance.config.dir}/ts.java.security \
+        -Dlogical.hostname.servlet=${logical.hostname.servlet} \
+        -Dcom.sun.aas.configRoot=${javaee.home}/config \
+        -Ddeliverable.class=${deliverable.class} $testExecuteClass $testExecuteArgs
+
+# Uncomment this for debugging standalone vehicle tests:
+#command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
+#        -v \
+#        CLASSPATH=${ts.harness.classpath}${pathsep}${ts.home}/classes${pathsep}\
+#        ${JAVA_HOME}/../lib/tools.jar${pathsep}\
+#        ${ri.modules}/security-ee.jar${pathsep}\
+#        ${ts.home}/lib/commons-httpclient-3.1.jar${pathsep}\
+#        ${ts.home}/lib/commons-logging-1.1.3.jar${pathsep}\
+#        ${ts.home}/lib/commons-codec-1.9.jar${pathsep}\
+#        ${ts.home}/lib/cssparser-0.9.25.jar${pathsep}\
+#        ${ts.home}/lib/htmlunit-2.15.jar${pathsep}\
+#        ${ts.home}/lib/htmlunit-core-js-2.15.jar${pathsep}\
+#        ${ts.home}/lib/httpcore-4.4.9.jar${pathsep}\
+#        ${ts.home}/lib/httpclient-4.5.5.jar${pathsep}\
+#        ${ts.home}/lib/httpmime-4.5.5.jar${pathsep}\
+#        ${ts.home}/lib/commons-collections-3.2.1.jar${pathsep}\
+#        ${ts.home}/lib/commons-io-2.4.jar${pathsep}\
+#        ${ts.home}/lib/commons-lang3-3.3.2.jar${pathsep}\
+#        ${ts.home}/lib/jaxen-1.1.6.jar${pathsep}\
+#        ${ts.home}/lib/nekohtml-1.9.21.jar${pathsep}\
+#        ${ts.home}/lib/sac-1.3.jar${pathsep}\
+#        ${ts.home}/lib/saxpath.jar${pathsep}\
+#        ${ts.home}/lib/xercesImpl-2.11.0.jar${pathsep}\
+#        ${ts.home}/lib/xalan-2.7.2.jar${pathsep}\
+#        ${ts.home}/lib/serializer-2.7.2.jar${pathsep}\
+#        ${ts.home}/lib/xml-apis-1.4.01.jar${pathsep}\
+#	${ts.home}/lib/unboundid-ldapsdk.jar${pathsep}\
+#        ${jdbc.db.classes} \
+#        DISPLAY=${ts.display} \
+#        HOME="${user.home}" \
+#        TMP=${TMP} \
+#        windir=${windir} \
+#        SYSTEMROOT=${SYSTEMROOT} \
+#        PATH="${javaee.home}/nativelib" \
+#        JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 \
+#        ${JAVA_HOME}/bin/java \
+#        -Dcts.tmp=$harness.temp.directory \
+#        -Djava.protocol.handler.pkgs=javax.net.ssl \
+#        -Djavax.net.ssl.keyStore=${bin.dir}/certificates/clientcert.jks \
+#        -Djavax.net.ssl.keyStorePassword=changeit \
+#        -Djavax.net.ssl.trustStore=${s1as.domain}/${sjsas.instance.config.dir}/cacerts.jks \
+#        -Djava.endorsed.dirs=${s1as.java.endorsed.dirs} \
+#        -Dcom.sun.aas.installRoot=${javaee.home} \
+#        -Dlog.file.location=${log.file.location} \
+#        -Dservlet.is.jsr115.compatible=${servlet.is.jsr115.compatible} \
+#        -Dprovider.configuration.file=${provider.configuration.file} \
+#        -Djava.security.properties=${s1as.domain}/${sjsas.instance.config.dir}/ts.java.security \
+#        -Dlogical.hostname.servlet=${logical.hostname.servlet} \
+#        -Dcom.sun.aas.configRoot=${javaee.home}/config \
+#        -Ddeliverable.class=${deliverable.class} $testExecuteClass $testExecuteArgs


### PR DESCRIPTION
Enabling execution for JDK17. To run it is needed to set the following variables:
export JDK=JDK17
export JAVA_HOME=/path/to/java17
export JDK17_HOME=/path/to/java17
export ANT_HOME=/path/to/ant
export MAVEN_HOME=/path/to/maven
export M2_HOME=/path/to/maven

suite already tested using the JDK 17: 
jsonb
`   [runcts] OUT => [javatest.batch] Total time = 142s
   [runcts] OUT => [javatest.batch] Setup time = 0s
   [runcts] OUT => [javatest.batch] Cleanup time = 15s
   [runcts] OUT => [javatest.batch] Test results: passed: 18
   [runcts] OUT => [javatest.batch] Results written to /home/alfv83/projects/jakartaeetck-runner/cts_home/jakartaeetck-work/jsonb.
   [runcts] OUT => [javatest.batch] Report written to /home/alfv83/projects/jakartaeetck-runner/cts_home/jakartaeetck-report/jsonb
   [runcts] OUT =>
   [runcts] OUT => BUILD SUCCESSFUL`

jsonp
`   [runcts] OUT => [javatest.batch] Total time = 292s
   [runcts] OUT => [javatest.batch] Setup time = 0s
   [runcts] OUT => [javatest.batch] Cleanup time = 16s
   [runcts] OUT => [javatest.batch] Test results: passed: 76
   [runcts] OUT => [javatest.batch] Results written to /home/alfv83/projects/jakartaeetck-runner/cts_home/jakartaeetck-work/jsonp.
   [runcts] OUT => [javatest.batch] Report written to /home/alfv83/projects/jakartaeetck-runner/cts_home/jakartaeetck-report/jsonp
   [runcts] OUT =>
   [runcts] OUT => BUILD SUCCESSFUL
   [runcts] OUT => Total time: 4 minutes 55 seconds`
