### PR TITLE
FISH-6823 - running JAXRS TCK with Web Profile

### DIFF
--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -355,7 +355,7 @@ else
 fi
 
 if [[ "$PROFILE" == "web" || "$PROFILE" == "WEB" ]];then
-  KEYWORDS="javaee_web_profile|jacc_web_profile|jaspic_web_profile|javamail_web_profile|connector_web_profile"
+   KEYWORDS="javaee_web_profile|jacc_web_profile|jaspic_web_profile|javamail_web_profile|connector_web_profile|jaxrs|jaxrs_web_profile"
 fi
 
 if [ -z "${vehicle}" ];then


### PR DESCRIPTION
Runs with the Web Profile were failing because of the suite Jaxrs not producing any results. In fact, the runner would only set up the environment but when checking the keywords, discarded running the tests, so producing no result to archive.
This PR adds the required keywords, and tests are run as shown in this run in Jenkins: https://jenkins.payara.fish/job/JakartaTCK-Dev/76/
Full run with this change:
https://jenkins.payara.fish/job/JakartaTCK-Dev/77/

Note: the keyword "jaxrs_web_profile" should be enough, but it doesn't work. I have raised the issue on the Eclipse repo:  https://github.com/jakartaee/platform-tck/issues/1167