### PR TITLE
FISH-7814 Use local files + Fix Policy Permissions

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -74,12 +74,6 @@ init_urls () {
     if [ -z "$DERBY_URL" ]; then
         DERBY_URL=$BASE_URL/javadb.zip
     fi
-    if [ -z "$EJBTIMER_DERBY_SQL" ]; then
-        EJBTIMER_DERBY_SQL=$BASE_URL/ejbtimer_derby.sql
-    fi
-    if [ -z "$JSR352_DERBY_SQL" ]; then
-        JSR352_DERBY_SQL=$BASE_URL/jsr352-derby.sql
-    fi      
 }
 
 make_stage_log () {

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -297,8 +297,8 @@ mv $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/db-derby* $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/j
 cp $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derbytools.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derbyshared.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derbyclient.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derby.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib
 rm ${CTS_HOME}/javadb.zip
 
-wget --progress=bar:force --no-cache $EJBTIMER_DERBY_SQL -O ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/ejbtimer_derby.sql
-wget --progress=bar:force --no-cache $JSR352_DERBY_SQL -O ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/jsr352-derby.sql
+cp $EJBTIMER_DERBY_SQL_PATH ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/ejbtimer_derby.sql
+cp $JSR352_DERBY_SQL_PATH ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/jsr352-derby.sql
 
 if [[ $test_suite == ejb30/lite* ]] || [[ "ejb30" == $test_suite ]] ; then
   echo "Using higher JVM memory for EJB Lite suites to avoid OOM errors"

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -290,11 +290,13 @@ fi
 
 wget --progress=bar:force --no-cache $DERBY_URL -O ${CTS_HOME}/javadb.zip
 
-echo -n "Unzipping JavaDB... "
+echo "Unzipping JavaDB..."
 unzip -q -o ${CTS_HOME}/javadb.zip -d $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR
 # apache derby is packed to directory like db-derby-10.14.2.0-bin
 mv $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/db-derby* $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb
 cp $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derbytools.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derbyshared.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derbyclient.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derby.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib
+echo "Additional libs in vi"
+ls -l $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib
 rm ${CTS_HOME}/javadb.zip
 
 cp $EJBTIMER_DERBY_SQL_PATH ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/ejbtimer_derby.sql
@@ -457,9 +459,14 @@ echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyi
 echo 'permission java.net.SocketPermission "*", "listen";' >> ${VI_SERVER_POLICY_FILE}
 echo 'permission java.net.SocketPermission "*", "accept";' >> ${VI_SERVER_POLICY_FILE}
 echo 'permission java.io.FilePermission       "<<ALL FILES>>", "write,read";' >> ${VI_SERVER_POLICY_FILE}
-echo 'permission org.apache.derby.shared.common.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_SERVER_POLICY_FILE}
+echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_SERVER_POLICY_FILE}
 echo '};' >> ${VI_SERVER_POLICY_FILE}
 
+VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy
+echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo '};' >> ${VI_APPCLIENT_POLICY_FILE}
 
 mkdir -p ${JT_REPORT_DIR}
 mkdir -p ${JT_WORK_DIR}
@@ -467,7 +474,17 @@ mkdir -p ${JT_WORK_DIR}
 export JAVA_VERSION=`java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}'`
 echo $JAVA_VERSION > ${JT_REPORT_DIR}/.jdk_version
 
+# For debugging purposes, look at the policies
+#echo "user's java policy"
+#cat ~/.java.policy
+#echo "appclient's java policy"
+#cat ${VI_APPCLIENT_POLICY_FILE}
+#echo "system policy"
+#cat ${JAVA_HOME}/conf/security/java.policy
+
 cd  ${TS_HOME}/bin
+export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
+# special syntax with "==" replaces system policy file
 ant ${ANT_ARG} config.vi.javadb
 ##### configVI.sh ends here #####
 

--- a/patch/run_jakartaeetck.sh
+++ b/patch/run_jakartaeetck.sh
@@ -269,8 +269,8 @@ unzip ${CTS_HOME}/javadb.zip -d $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR
 cp $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derbyclient.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derby.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib
 rm ${CTS_HOME}/javadb.zip
 
-wget --progress=bar:force --no-cache $EJBTIMER_DERBY_SQL -O ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/ejbtimer_derby.sql
-wget --progress=bar:force --no-cache $JSR352_DERBY_SQL -O ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/jsr352-derby.sql
+cp $EJBTIMER_DERBY_SQL_PATH ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/ejbtimer_derby.sql
+cp $JSR352_DERBY_SQL_PATH ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/jsr352-derby.sql
 
 if [[ $test_suite == ejb30/lite* ]] || [[ "ejb30" == $test_suite ]] ; then
   echo "Using higher JVM memory for EJB Lite suites to avoid OOM errors"

--- a/run.sh
+++ b/run.sh
@@ -109,8 +109,8 @@ export GF_VI_BUNDLE_URL=$PAYARA_URL
 export PAYARA_VERSION=$PAYARA_VERSION
 export GF_VI_TOPLEVEL_DIR=payara6
 export DERBY_URL
-export EJBTIMER_DERBY_SQL
-export JSR352_DERBY_SQL
+export EJBTIMER_DERBY_SQL_PATH=./bundles/ejbtimer_derby.sql
+export JSR352_DERBY_SQL_PATH=./bundles/jsr352-derby.sql
 
 TEST_SUITE=`echo "$1" | tr '/' '_'`
 


### PR DESCRIPTION
James' commit: use local derby libraries instead of via http

my commit: specify security policies for ant; the new Jenkins was failing due to insufficient permissions

On the new Jenkins, TCK-Suite, build 11 succeeded with these changes.