### PR TITLE
FISH-8073 Fix Jakarta EE8 TCKs

### DIFF
--- a/bundles/download.sh
+++ b/bundles/download.sh
@@ -1,5 +1,5 @@
 if [ ! -f jakartaeetck.zip ]; then
-  wget --read-timeout=20 http://download.eclipse.org/jakartaee/platform/8/eclipse-jakartaeetck-8.0.1.zip -O jakartaeetck.zip
+  wget --read-timeout=20 http://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.3.zip -O jakartaeetck.zip
 fi
 if [ ! -f cdi-tck-2.0.6-dist.zip ]; then
   wget http://download.eclipse.org/ee4j/cdi/cdi-tck-2.0.6-dist.zip

--- a/cdi/build.sh
+++ b/cdi/build.sh
@@ -20,6 +20,16 @@ rm -rf $PORTING/payara5
 
 export WORKSPACE=$SCRIPTPATH/cditck-porting
 export GF_BUNDLE_URL=$PAYARA_URL
+
+echo "Setting up max.classes.restart"
+if grep "^max.classes.restart=" ${WORKSPACE}/build.properties
+then
+  echo "max.classes.restart settings already exists"
+else
+  echo "# The restarts can cause issues -- once fixed, remove the max.classes.restart settings" >> ${WORKSPACE}/build.properties
+  echo "max.classes.restart=10000" >> ${WORKSPACE}/build.properties
+fi
+
 echo Build should download from $GF_BUNDLE_URL
 bash -x $WORKSPACE/docker/build_cditck.sh
 

--- a/cdi/run.sh
+++ b/cdi/run.sh
@@ -25,16 +25,6 @@ fi
 
 rm -rf $WORKSPACE/cdi-tck-glassfish-porting
 
-echo "Setting up max.classes.restart"
-if grep "^max.classes.restart=" ${WORKSPACE}/build.properties
-then
-  echo "max.classes.restart settings already exists"
-else
-  echo "# The restarts can cause issues -- once fixed, remove the max.classes.restart settings" >> ${WORKSPACE}/build.properties
-  echo "max.classes.restart=10000" >> ${WORKSPACE}/build.properties
-fi
-#read -p "Press any key to resume ..."
-
 bash -x $WORKSPACE/docker/run_cditck.sh | tee $WORKSPACE/cdi.log
 
 TIMESTAMP=`date -Iminutes | tr -d :`

--- a/cdi/run.sh
+++ b/cdi/run.sh
@@ -25,6 +25,15 @@ fi
 
 rm -rf $WORKSPACE/cdi-tck-glassfish-porting
 
+if grep "^max.classes.restart=" ${WORKSPACE}/build.properties
+then
+  echo "max.classes.restart settings already exists"
+else
+  echo "# The restarts can cause issues -- once fixed, remove the max.classes.restart settings" >> ${WORKSPACE}/build.properties
+  echo "max.classes.restart=10000" >> ${WORKSPACE}/build.properties
+fi
+read -p "Press any key to resume ..."
+
 bash -x $WORKSPACE/docker/run_cditck.sh | tee $WORKSPACE/cdi.log
 
 TIMESTAMP=`date -Iminutes | tr -d :`

--- a/cdi/run.sh
+++ b/cdi/run.sh
@@ -25,6 +25,7 @@ fi
 
 rm -rf $WORKSPACE/cdi-tck-glassfish-porting
 
+echo "Setting up max.classes.restart"
 if grep "^max.classes.restart=" ${WORKSPACE}/build.properties
 then
   echo "max.classes.restart settings already exists"
@@ -32,7 +33,7 @@ else
   echo "# The restarts can cause issues -- once fixed, remove the max.classes.restart settings" >> ${WORKSPACE}/build.properties
   echo "max.classes.restart=10000" >> ${WORKSPACE}/build.properties
 fi
-read -p "Press any key to resume ..."
+#read -p "Press any key to resume ..."
 
 bash -x $WORKSPACE/docker/run_cditck.sh | tee $WORKSPACE/cdi.log
 

--- a/functions.sh
+++ b/functions.sh
@@ -59,6 +59,8 @@ init_urls () {
     # set *_TCK_BUNDLE_URL here!
     # remove setup from https://github.com/payara/EngineeringJenkinsjobs/blob/dff9a4e26440830394c3dc7f93c701eba8bf1fab/TCK-Suite/Jenkinsfile#L321
     # remove comment https://github.com/payara/EngineeringJenkinsjobs/blob/dff9a4e26440830394c3dc7f93c701eba8bf1fab/TCK-Suite/Jenkinsfile#L314
+    TCK_URL=https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.3.zip
+
     BV_TCK_BUNDLE_URL=http://download.eclipse.org/ee4j/bean-validation/beanvalidation-tck-dist-2.0.5.zip 
 
     CDI_TCK_URL=http://download.eclipse.org/ee4j/cdi/cdi-tck-2.0.6-dist.zip

--- a/functions.sh
+++ b/functions.sh
@@ -64,12 +64,6 @@ init_urls () {
     if [ -z "$DERBY_URL" ]; then
         DERBY_URL=$BASE_URL/javadb.zip
     fi
-    if [ -z "$EJBTIMER_DERBY_SQL" ]; then
-        EJBTIMER_DERBY_SQL=$BASE_URL/ejbtimer_derby.sql
-    fi
-    if [ -z "$JSR352_DERBY_SQL" ]; then
-        JSR352_DERBY_SQL=$BASE_URL/jsr352-derby.sql
-    fi      
 }
 
 make_stage_log () {

--- a/functions.sh
+++ b/functions.sh
@@ -64,6 +64,11 @@ init_urls () {
     if [ -z "$DERBY_URL" ]; then
         DERBY_URL=$BASE_URL/javadb.zip
     fi
+
+    # set BV_TCK_BUNDLE_URL here!
+    # remove setup from https://github.com/payara/EngineeringJenkinsjobs/blob/dff9a4e26440830394c3dc7f93c701eba8bf1fab/TCK-Suite/Jenkinsfile#L321
+    # remove comment https://github.com/payara/EngineeringJenkinsjobs/blob/dff9a4e26440830394c3dc7f93c701eba8bf1fab/TCK-Suite/Jenkinsfile#L314
+    BV_TCK_BUNDLE_URL=http://download.eclipse.org/ee4j/bean-validation/beanvalidation-tck-dist-2.0.5.zip 
 }
 
 make_stage_log () {

--- a/functions.sh
+++ b/functions.sh
@@ -49,26 +49,22 @@ init_urls () {
     if [ -z "$TCK_URL" ]; then
         TCK_URL=$BASE_URL/jakartaeetck.zip
     fi
-    if [ -z "$GLASSFISH_URL" ]; then
-        GLASSFISH_URL=$BASE_URL/latest-glassfish.zip
-    fi
     if [ -z "$PAYARA_URL" ]; then
         PAYARA_URL=$BASE_URL/payara-prerelease.zip
-    fi
-    if [ -z "$CDI_TCK_URL" ]; then
-        CDI_TCK_URL=$BASE_URL/cdi-tck-2.0.6-dist.zip
-    fi
-    if [ -z "$DI_TCK_URL" ]; then
-        DI_TCK_URL=$BASE_URL/jakarta.inject-tck-1.0-bin.zip
     fi
     if [ -z "$DERBY_URL" ]; then
         DERBY_URL=$BASE_URL/javadb.zip
     fi
 
-    # set BV_TCK_BUNDLE_URL here!
+    # set *_TCK_BUNDLE_URL here!
     # remove setup from https://github.com/payara/EngineeringJenkinsjobs/blob/dff9a4e26440830394c3dc7f93c701eba8bf1fab/TCK-Suite/Jenkinsfile#L321
     # remove comment https://github.com/payara/EngineeringJenkinsjobs/blob/dff9a4e26440830394c3dc7f93c701eba8bf1fab/TCK-Suite/Jenkinsfile#L314
     BV_TCK_BUNDLE_URL=http://download.eclipse.org/ee4j/bean-validation/beanvalidation-tck-dist-2.0.5.zip 
+
+    CDI_TCK_URL=http://download.eclipse.org/ee4j/cdi/cdi-tck-2.0.6-dist.zip
+    DI_TCK_URL=http://download.eclipse.org/ee4j/cdi/jakarta.inject-tck-1.0-bin.zip
+    
+    GLASSFISH_URL=https://download.eclipse.org/glassfish/glassfish-5.1.0.zip
 }
 
 make_stage_log () {

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -411,13 +411,24 @@ fi
 
 VI_SERVER_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/domains/domain1/config/server.policy
 echo 'grant {' >> ${VI_SERVER_POLICY_FILE}
+if [ "ejb30/sec" == "${test_suite}" ]; then
+  # ejb30/sec fails with AllPermission
+else
+  echo "Setting AllPermission if not ejb30/sec"
+  echo 'permission java.security.AllPermission;' >> ${VI_SERVER_POLICY_FILE}
+fi
 echo 'permission java.io.FilePermission "${com.sun.aas.instanceRoot}${/}generated${/}policy${/}-", "read,write,execute,delete";' >> ${VI_SERVER_POLICY_FILE}
 echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_SERVER_POLICY_FILE}
 echo '};' >> ${VI_SERVER_POLICY_FILE}
 
 VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy
 echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
-#echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}
+if [ "ejb30/sec" == "${test_suite}" ]; then
+  # ejb30/sec fails with AllPermission
+else
+  echo "Setting AllPermission if not ejb30/sec"
+  echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}
+fi
 # If anybody want to continue in specifying all permissions, this is incomplete list:
 echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
 echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -451,7 +451,7 @@ export JAVA_VERSION=`java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}'`
 echo $JAVA_VERSION > ${JT_REPORT_DIR}/.jdk_version
 
 cd  ${TS_HOME}/bin
-export ANT_ARG="${ANT_ARG} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
+export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
 ant ${ANT_ARG} config.vi.javadb
 ##### configVI.sh ends here #####
 

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -429,7 +429,7 @@ echo '};' >> ${VI_SERVER_POLICY_FILE}
 
 VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy
 echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
-if [ "compat12" == "${test_suite}" ] || [ "connector" == "${test_suite}" ] || [ "ejb" == "${test_suite}" ] || [ "ejb30/sec" == "${test_suite}" ] || [ "integration" == "${test_suite}" ] || [ "interop_forward" == "${test_suite}" ] || [ "interop_reverse" == "${test_suite}" ] || [ "jacc" == "${test_suite}" ] || [ "jaspic" == "${test_suite}" ] || [ "jaxrpc" == "${test_suite}" ] || [ "jaxrs" == "${test_suite}" ] || [ "jbatch" == "${test_suite}" ] || [ "jsp" == "${test_suite}" ] || [ "securityapi" == "${test_suite}" ] || [ "servlet" == "${test_suite}" ] || [ "webservices" == "${test_suite}" ] || [ "webservices12" == "${test_suite}" ] || [ "websocket" == "${test_suite}" ]; then
+if [ "compat12" == "${test_suite}" ] || [ "connector" == "${test_suite}" ] || [ "ejb" == "${test_suite}" ] || [ "ejb30/sec" == "${test_suite}" ] || [ "integration" == "${test_suite}" ] || [ "interop_forward" == "${test_suite}" ] || [ "interop_reverse" == "${test_suite}" ] || [ "jacc" == "${test_suite}" ] || [ "jaspic" == "${test_suite}" ] || [ "jaxrpc" == "${test_suite}" ] || [ "jaxrs" == "${test_suite}" ] || [ "jbatch" == "${test_suite}" ] || [ "jsp" == "${test_suite}" ] || [ "securityapi" == "${test_suite}" ] || [ "servlet" == "${test_suite}" ] || [ "webservices" == "${test_suite}" ] || [ "websocket" == "${test_suite}" ]; then
   # ejb30/sec fails with AllPermission
   echo "Setting specific permissions, not AllPermission"
   # If anybody want to continue in specifying all permissions, this is incomplete list:
@@ -459,8 +459,8 @@ cd  ${TS_HOME}/bin
 # permit everything for preparational ant
 export ANT_ARG="${ANT_ARG} -Djava.security.manager -Djava.security.policy==${ALLPERMISSION_POLICY_FILE}"
 # configure ant client to use client policy file
-#export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
-export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${ALLPERMISSION_POLICY_FILE}"
+export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
+#export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${ALLPERMISSION_POLICY_FILE}"
 ant ${ANT_ARG} config.vi.javadb
 echo "config vi ends here"
 ##### configVI.sh ends here #####

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -444,6 +444,10 @@ if [ "compat12" == "${test_suite}" ] || [ "connector" == "${test_suite}" ] || [ 
   echo 'permission "java.lang.RuntimePermission" "accessDeclaredMembers";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.lang.RuntimePermission" "getProtectionDomain";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.util.PropertyPermission" "*", "read, write";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "java.lang.RuntimePermission" "accessUserInformation";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "java.lang.RuntimePermission" "shutdownHooks";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "org.glassfish.pfl.basic.reflection.BridgePermission" "getBridge";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "javax.xml.ws.WebServicePermission" "ConnectorPermission1_name2");' >> ${VI_APPCLIENT_POLICY_FILE}
 else
   echo "Setting AllPermission"
   echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -428,6 +428,7 @@ echo 'permission "java.lang.RuntimePermission" "setIO";' >> ${VI_APPCLIENT_POLIC
 echo 'permission "java.lang.RuntimePermission" "accessDeclaredMembers";' >> ${VI_APPCLIENT_POLICY_FILE}
 echo 'permission "java.lang.RuntimePermission" "getProtectionDomain";' >> ${VI_APPCLIENT_POLICY_FILE}
 echo 'permission "java.util.PropertyPermission" "*", "read, write";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission "java.io.FilePermission" "*", "execute, delete";' >> ${VI_APPCLIENT_POLICY_FILE}
 echo '};' >> ${VI_APPCLIENT_POLICY_FILE}
 
 mkdir -p ${JT_REPORT_DIR}
@@ -437,7 +438,7 @@ export JAVA_VERSION=`java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}'`
 echo $JAVA_VERSION > ${JT_REPORT_DIR}/.jdk_version
 
 cd  ${TS_HOME}/bin
-export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
+export ANT_ARG="${ANT_ARG} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
 ant ${ANT_ARG} config.vi.javadb
 ##### configVI.sh ends here #####
 

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -417,8 +417,17 @@ echo '};' >> ${VI_SERVER_POLICY_FILE}
 
 VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy
 echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
-echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
-echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}
+# If anybody want to continue in specifying all permissions, this is incomplete list:
+# echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
+# echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}
+# echo 'permission "java.lang.RuntimePermission" "getClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
+# echo 'permission "java.lang.RuntimePermission" "createClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
+# echo 'permission "java.lang.RuntimePermission" "setContextClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
+# echo 'permission "java.lang.RuntimePermission" "setIO";' >> ${VI_APPCLIENT_POLICY_FILE}
+# echo 'permission "java.lang.RuntimePermission" "accessDeclaredMembers";' >> ${VI_APPCLIENT_POLICY_FILE}
+# echo 'permission "java.lang.RuntimePermission" "getProtectionDomain";' >> ${VI_APPCLIENT_POLICY_FILE}
+# echo 'permission "java.util.PropertyPermission" "*", "read, write";' >> ${VI_APPCLIENT_POLICY_FILE}
 echo '};' >> ${VI_APPCLIENT_POLICY_FILE}
 
 mkdir -p ${JT_REPORT_DIR}

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -409,28 +409,28 @@ if [ ! -z "${DATABASE}" ];then
   fi
 fi
 
-echo 'grant {' >> /tmp/allpermission.policy
+echo 'grant {' > /tmp/allpermission.policy
 echo 'permission java.security.AllPermission;' >> /tmp/allpermission.policy
 echo '};' >> /tmp/allpermission.policy
 
 VI_SERVER_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/domains/domain1/config/server.policy
 echo 'grant {' >> ${VI_SERVER_POLICY_FILE}
-if [ "ejb30/sec" == "${test_suite}" ] || [ "webservices12" == "${test_suite}" ]; then
+# if [ "ejb30/sec" == "${test_suite}" ] || [ "webservices12" == "${test_suite}" ]; then
   # ejb30/sec fails with AllPermission
-  echo "Setting permissions for ejb30/sec, not AllPermission"
+#   echo "Setting permissions for ejb30/sec, not AllPermission"
   echo 'permission java.io.FilePermission "${com.sun.aas.instanceRoot}${/}generated${/}policy${/}-", "read,write,execute,delete";' >> ${VI_SERVER_POLICY_FILE}
   echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_SERVER_POLICY_FILE}
-else
-  echo "Setting AllPermission if not ejb30/sec"
-  echo 'permission java.security.AllPermission;' >> ${VI_SERVER_POLICY_FILE}
-fi
+# else
+#   echo "Setting AllPermission if not ejb30/sec"
+#   echo 'permission java.security.AllPermission;' >> ${VI_SERVER_POLICY_FILE}
+# fi
 echo '};' >> ${VI_SERVER_POLICY_FILE}
 
 VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy
 echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
-if [ "ejb30/sec" == "${test_suite}" ] || [ "webservices12" == "${test_suite}" ]; then
+#if [ "ejb30/sec" == "${test_suite}" ] || [ "webservices12" == "${test_suite}" ]; then
   # ejb30/sec fails with AllPermission
-  echo "Setting permissions for ejb30/sec, not AllPermission, enumerate the needed ones"
+#   echo "Setting permissions for ejb30/sec, not AllPermission, enumerate the needed ones"
   # If anybody want to continue in specifying all permissions, this is incomplete list:
   echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}
@@ -442,10 +442,10 @@ if [ "ejb30/sec" == "${test_suite}" ] || [ "webservices12" == "${test_suite}" ];
   echo 'permission "java.lang.RuntimePermission" "getProtectionDomain";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.util.PropertyPermission" "*", "read, write";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.io.FilePermission" "*", "execute, delete";' >> ${VI_APPCLIENT_POLICY_FILE}
-else
-  echo "Setting AllPermission if not ejb30/sec"
-  echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}
-fi
+# else
+#   echo "Setting AllPermission if not ejb30/sec"
+#   echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}
+# fi
 echo '};' >> ${VI_APPCLIENT_POLICY_FILE}
 
 mkdir -p ${JT_REPORT_DIR}
@@ -455,8 +455,11 @@ export JAVA_VERSION=`java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}'`
 echo $JAVA_VERSION > ${JT_REPORT_DIR}/.jdk_version
 
 cd  ${TS_HOME}/bin
+# permit everything for preparational ant
+export ANT_ARG="${ANT_ARG} -Djava.security.manager -Djava.security.policy==/tmp/allpermission.policy"
+# configure ant client to use client policy file
 export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
-ant ${ANT_ARG} -Djava.security.manager -Djava.security.policy==/tmp/allpermission.policy config.vi.javadb
+ant ${ANT_ARG} config.vi.javadb
 ##### configVI.sh ends here #####
 
 ### populateMailbox for suites using mail server - Start ###

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -254,7 +254,7 @@ if [ ! -d "${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR" ]; then
   exit 1
 fi
 
-wget --progress=bar:force --no-cache $DERBY_URL -O ${CTS_HOME}/javadb.zip
+cp $DERBY_PATH ${CTS_HOME}/javadb.zip
 
 echo "Unzipping JavaDB... "
 unzip -q -o ${CTS_HOME}/javadb.zip -d $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -429,7 +429,7 @@ echo '};' >> ${VI_SERVER_POLICY_FILE}
 
 VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy
 echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
-if [ "compat12" == "${test_suite}" ] || [ "connector" == "${test_suite}" ] || [ "ejb" == "${test_suite}" ] || [ "ejb30/sec" == "${test_suite}" ] || [ "integration" == "${test_suite}" ] || [ "interop_forward" == "${test_suite}" ] || [ "interop_reverse" == "${test_suite}" ] || [ "jacc" == "${test_suite}" ] || [ "jaspic" == "${test_suite}" ] || [ "jaxrpc" == "${test_suite}" ] || [ "jaxrs" == "${test_suite}" ] || [ "jbatch" == "${test_suite}" ] || [ "jsp" == "${test_suite}" ] || [ "securityapi" == "${test_suite}" ] || [ "servlet" == "${test_suite}" ] || [ "webservices" == "${test_suite}" ] || [ "websocket" == "${test_suite}" ]; then
+if [ "compat12" == "${test_suite}" ] || [ "connector" == "${test_suite}" ] || [ "ejb" == "${test_suite}" ] || [ "ejb30/sec" == "${test_suite}" ] || [ "integration" == "${test_suite}" ] || [ "jacc" == "${test_suite}" ] || [ "jaspic" == "${test_suite}" ] || [ "jaxrpc" == "${test_suite}" ] || [ "jaxrs" == "${test_suite}" ] || [ "jbatch" == "${test_suite}" ] || [ "jsp" == "${test_suite}" ] || [ "securityapi" == "${test_suite}" ] || [ "servlet" == "${test_suite}" ] || [ "webservices" == "${test_suite}" ] || [ "websocket" == "${test_suite}" ]; then
   # ejb30/sec fails with AllPermission
   echo "Setting specific permissions, not AllPermission"
   # If anybody want to continue in specifying all permissions, this is incomplete list:

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -413,6 +413,7 @@ VI_SERVER_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/domains/domai
 echo 'grant {' >> ${VI_SERVER_POLICY_FILE}
 if [ "ejb30/sec" == "${test_suite}" ]; then
   # ejb30/sec fails with AllPermission
+  echo "Not setting AllPermission for ejb30/sec"
 else
   echo "Setting AllPermission if not ejb30/sec"
   echo 'permission java.security.AllPermission;' >> ${VI_SERVER_POLICY_FILE}
@@ -425,6 +426,7 @@ VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appcli
 echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
 if [ "ejb30/sec" == "${test_suite}" ]; then
   # ejb30/sec fails with AllPermission
+  echo "Not setting AllPermission for ejb30/sec"
 else
   echo "Setting AllPermission if not ejb30/sec"
   echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -409,11 +409,15 @@ if [ ! -z "${DATABASE}" ];then
   fi
 fi
 
+echo 'grant {' >> /tmp/allpermission.policy
+echo 'permission java.security.AllPermission;' >> /tmp/allpermission.policy
+echo '};' >> /tmp/allpermission.policy
+
 VI_SERVER_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/domains/domain1/config/server.policy
 echo 'grant {' >> ${VI_SERVER_POLICY_FILE}
-if [ "ejb30/sec" == "${test_suite}" ]; then
+if [ "ejb30/sec" == "${test_suite}" ] || [ "webservices12" == "${test_suite}" ]; then
   # ejb30/sec fails with AllPermission
-  echo "Not setting AllPermission for ejb30/sec"
+  echo "Setting permissions for ejb30/sec, not AllPermission"
   echo 'permission java.io.FilePermission "${com.sun.aas.instanceRoot}${/}generated${/}policy${/}-", "read,write,execute,delete";' >> ${VI_SERVER_POLICY_FILE}
   echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_SERVER_POLICY_FILE}
 else
@@ -424,9 +428,9 @@ echo '};' >> ${VI_SERVER_POLICY_FILE}
 
 VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy
 echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
-if [ "ejb30/sec" == "${test_suite}" ]; then
+if [ "ejb30/sec" == "${test_suite}" ] || [ "webservices12" == "${test_suite}" ]; then
   # ejb30/sec fails with AllPermission
-  echo "Not setting AllPermission for ejb30/sec, enumerate the needed ones"
+  echo "Setting permissions for ejb30/sec, not AllPermission, enumerate the needed ones"
   # If anybody want to continue in specifying all permissions, this is incomplete list:
   echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}
@@ -452,7 +456,7 @@ echo $JAVA_VERSION > ${JT_REPORT_DIR}/.jdk_version
 
 cd  ${TS_HOME}/bin
 export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
-ant ${ANT_ARG} config.vi.javadb
+ant ${ANT_ARG} -Djava.security.manager -Djava.security.policy==/tmp/allpermission.policy config.vi.javadb
 ##### configVI.sh ends here #####
 
 ### populateMailbox for suites using mail server - Start ###

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -261,8 +261,8 @@ unzip -q -o ${CTS_HOME}/javadb.zip -d $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR
 cp $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derbyclient.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derby.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib
 rm ${CTS_HOME}/javadb.zip
 
-wget --progress=bar:force --no-cache $EJBTIMER_DERBY_SQL -O ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/ejbtimer_derby.sql
-wget --progress=bar:force --no-cache $JSR352_DERBY_SQL -O ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/jsr352-derby.sql
+cp $EJBTIMER_DERBY_SQL_PATH ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/ejbtimer_derby.sql
+cp $JSR352_DERBY_SQL_PATH ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/jsr352-derby.sql
 
 if [[ $test_suite == ejb30/lite* ]] || [[ "ejb30" == $test_suite ]] ; then
   echo "Using higher JVM memory for EJB Lite suites to avoid OOM errors"

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -417,17 +417,17 @@ echo '};' >> ${VI_SERVER_POLICY_FILE}
 
 VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy
 echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
-echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}
+#echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}
 # If anybody want to continue in specifying all permissions, this is incomplete list:
-# echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
-# echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}
-# echo 'permission "java.lang.RuntimePermission" "getClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
-# echo 'permission "java.lang.RuntimePermission" "createClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
-# echo 'permission "java.lang.RuntimePermission" "setContextClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
-# echo 'permission "java.lang.RuntimePermission" "setIO";' >> ${VI_APPCLIENT_POLICY_FILE}
-# echo 'permission "java.lang.RuntimePermission" "accessDeclaredMembers";' >> ${VI_APPCLIENT_POLICY_FILE}
-# echo 'permission "java.lang.RuntimePermission" "getProtectionDomain";' >> ${VI_APPCLIENT_POLICY_FILE}
-# echo 'permission "java.util.PropertyPermission" "*", "read, write";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission "java.lang.RuntimePermission" "getClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission "java.lang.RuntimePermission" "createClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission "java.lang.RuntimePermission" "setContextClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission "java.lang.RuntimePermission" "setIO";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission "java.lang.RuntimePermission" "accessDeclaredMembers";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission "java.lang.RuntimePermission" "getProtectionDomain";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission "java.util.PropertyPermission" "*", "read, write";' >> ${VI_APPCLIENT_POLICY_FILE}
 echo '};' >> ${VI_APPCLIENT_POLICY_FILE}
 
 mkdir -p ${JT_REPORT_DIR}

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -2,7 +2,7 @@
 
 #
 # Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2019, 2020 Payara Foundation and/or its affiliates. All rights reserved.
+# Copyright (c) 2019-2023 Payara Foundation and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -256,9 +256,11 @@ fi
 
 wget --progress=bar:force --no-cache $DERBY_URL -O ${CTS_HOME}/javadb.zip
 
-echo -n "Unzipping JavaDB... "
+echo "Unzipping JavaDB... "
 unzip -q -o ${CTS_HOME}/javadb.zip -d $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR
 cp $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derbyclient.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derby.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib
+echo "Additional libs in vi"
+ls -l $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib
 rm ${CTS_HOME}/javadb.zip
 
 cp $EJBTIMER_DERBY_SQL_PATH ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/ejbtimer_derby.sql
@@ -410,8 +412,14 @@ fi
 VI_SERVER_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/domains/domain1/config/server.policy
 echo 'grant {' >> ${VI_SERVER_POLICY_FILE}
 echo 'permission java.io.FilePermission "${com.sun.aas.instanceRoot}${/}generated${/}policy${/}-", "read,write,execute,delete";' >> ${VI_SERVER_POLICY_FILE}
+echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_SERVER_POLICY_FILE}
 echo '};' >> ${VI_SERVER_POLICY_FILE}
 
+VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy
+echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}
+echo '};' >> ${VI_APPCLIENT_POLICY_FILE}
 
 mkdir -p ${JT_REPORT_DIR}
 mkdir -p ${JT_WORK_DIR}
@@ -420,6 +428,7 @@ export JAVA_VERSION=`java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}'`
 echo $JAVA_VERSION > ${JT_REPORT_DIR}/.jdk_version
 
 cd  ${TS_HOME}/bin
+export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
 ant ${ANT_ARG} config.vi.javadb
 ##### configVI.sh ends here #####
 

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -409,28 +409,29 @@ if [ ! -z "${DATABASE}" ];then
   fi
 fi
 
-echo 'grant {' > /tmp/allpermission.policy
-echo 'permission java.security.AllPermission;' >> /tmp/allpermission.policy
-echo '};' >> /tmp/allpermission.policy
+ALLPERMISSION_POLICY_FILE=/tmp/allpermission.policy
+echo 'grant {' > ${ALLPERMISSION_POLICY_FILE}
+echo 'permission java.security.AllPermission;' >> ${ALLPERMISSION_POLICY_FILE}
+echo '};' >> ${ALLPERMISSION_POLICY_FILE}
 
 VI_SERVER_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/domains/domain1/config/server.policy
 echo 'grant {' >> ${VI_SERVER_POLICY_FILE}
 # if [ "ejb30/sec" == "${test_suite}" ] || [ "webservices12" == "${test_suite}" ]; then
-  # ejb30/sec fails with AllPermission
-#   echo "Setting permissions for ejb30/sec, not AllPermission"
+  #ejb30/sec fails with AllPermission
+#   echo "Setting specific permissions for ejb30/sec, not AllPermission"
   echo 'permission java.io.FilePermission "${com.sun.aas.instanceRoot}${/}generated${/}policy${/}-", "read,write,execute,delete";' >> ${VI_SERVER_POLICY_FILE}
   echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_SERVER_POLICY_FILE}
 # else
-#   echo "Setting AllPermission if not ejb30/sec"
+#   echo "Setting AllPermission"
 #   echo 'permission java.security.AllPermission;' >> ${VI_SERVER_POLICY_FILE}
 # fi
 echo '};' >> ${VI_SERVER_POLICY_FILE}
 
 VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy
 echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
-#if [ "ejb30/sec" == "${test_suite}" ] || [ "webservices12" == "${test_suite}" ]; then
+if [ "compat12" == "${test_suite}" ] || [ "connector" == "${test_suite}" ] || [ "ejb" == "${test_suite}" ] || [ "ejb30/sec" == "${test_suite}" ] || [ "integration" == "${test_suite}" ] || [ "interop_forward" == "${test_suite}" ] || [ "interop_reverse" == "${test_suite}" ] || [ "jacc" == "${test_suite}" ] || [ "jaspic" == "${test_suite}" ] || [ "jaxrpc" == "${test_suite}" ] || [ "jaxrs" == "${test_suite}" ] || [ "jbatch" == "${test_suite}" ] || [ "jsp" == "${test_suite}" ] || [ "securityapi" == "${test_suite}" ] || [ "servlet" == "${test_suite}" ] || [ "webservices" == "${test_suite}" ] || [ "webservices12" == "${test_suite}" ] || [ "websocket" == "${test_suite}" ]; then
   # ejb30/sec fails with AllPermission
-#   echo "Setting permissions for ejb30/sec, not AllPermission, enumerate the needed ones"
+  echo "Setting specific permissions, not AllPermission"
   # If anybody want to continue in specifying all permissions, this is incomplete list:
   echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}
@@ -442,10 +443,10 @@ echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.lang.RuntimePermission" "getProtectionDomain";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.util.PropertyPermission" "*", "read, write";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.io.FilePermission" "*", "execute, delete";' >> ${VI_APPCLIENT_POLICY_FILE}
-# else
-#   echo "Setting AllPermission if not ejb30/sec"
-#   echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}
-# fi
+else
+  echo "Setting AllPermission"
+  echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}
+fi
 echo '};' >> ${VI_APPCLIENT_POLICY_FILE}
 
 mkdir -p ${JT_REPORT_DIR}
@@ -456,10 +457,12 @@ echo $JAVA_VERSION > ${JT_REPORT_DIR}/.jdk_version
 
 cd  ${TS_HOME}/bin
 # permit everything for preparational ant
-export ANT_ARG="${ANT_ARG} -Djava.security.manager -Djava.security.policy==/tmp/allpermission.policy"
+export ANT_ARG="${ANT_ARG} -Djava.security.manager -Djava.security.policy==${ALLPERMISSION_POLICY_FILE}"
 # configure ant client to use client policy file
-export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
+#export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
+export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${ALLPERMISSION_POLICY_FILE}"
 ant ${ANT_ARG} config.vi.javadb
+echo "config vi ends here"
 ##### configVI.sh ends here #####
 
 ### populateMailbox for suites using mail server - Start ###

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -429,10 +429,12 @@ echo '};' >> ${VI_SERVER_POLICY_FILE}
 
 VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy
 echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
-if [ "compat12" == "${test_suite}" ] || [ "connector" == "${test_suite}" ] || [ "ejb" == "${test_suite}" ] || [ "ejb30/sec" == "${test_suite}" ] || [ "integration" == "${test_suite}" ] || [ "jacc" == "${test_suite}" ] || [ "jaspic" == "${test_suite}" ] || [ "jaxrpc" == "${test_suite}" ] || [ "jaxrs" == "${test_suite}" ] || [ "jbatch" == "${test_suite}" ] || [ "jsp" == "${test_suite}" ] || [ "securityapi" == "${test_suite}" ] || [ "servlet" == "${test_suite}" ] || [ "webservices" == "${test_suite}" ] || [ "websocket" == "${test_suite}" ]; then
+if [ "compat12" == "${test_suite}" ] || [ "connector" == "${test_suite}" ] || [ "ejb" == "${test_suite}" ] || [ "ejb30/sec" == "${test_suite}" ] || [ "integration" == "${test_suite}" ] || [ "jacc" == "${test_suite}" ] || [ "jaspic" == "${test_suite}" ] || [ "jaxrpc" == "${test_suite}" ] || [ "jaxrs" == "${test_suite}" ] || [ "jbatch" == "${test_suite}" ] || [ "jsp" == "${test_suite}" ] || [ "securityapi" == "${test_suite}" ] || [ "servlet" == "${test_suite}" ] || [ "webservices" == "${test_suite}" ] || [ "websocket" == "${test_suite}" ] ]; then
+  #  || [ "interop" == "${test_suite}"
   # ejb30/sec fails with AllPermission
   echo "Setting specific permissions, not AllPermission"
   # If anybody want to continue in specifying all permissions, this is incomplete list:
+  echo 'permission "java.io.FilePermission" "<<ALL FILES>>", "execute, delete";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.lang.RuntimePermission" "getClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
@@ -442,7 +444,6 @@ if [ "compat12" == "${test_suite}" ] || [ "connector" == "${test_suite}" ] || [ 
   echo 'permission "java.lang.RuntimePermission" "accessDeclaredMembers";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.lang.RuntimePermission" "getProtectionDomain";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.util.PropertyPermission" "*", "read, write";' >> ${VI_APPCLIENT_POLICY_FILE}
-  echo 'permission "java.io.FilePermission" "*", "execute, delete";' >> ${VI_APPCLIENT_POLICY_FILE}
 else
   echo "Setting AllPermission"
   echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}
@@ -456,12 +457,12 @@ export JAVA_VERSION=`java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}'`
 echo $JAVA_VERSION > ${JT_REPORT_DIR}/.jdk_version
 
 cd  ${TS_HOME}/bin
-# permit everything for preparational ant
-export ANT_ARG="${ANT_ARG} -Djava.security.manager -Djava.security.policy==${ALLPERMISSION_POLICY_FILE}"
+# permit everything for configuration ant runs
+export CONFIG_ARG="${ANT_ARG} -Djava.security.manager -Djava.security.policy==${ALLPERMISSION_POLICY_FILE}"
 # configure ant client to use client policy file
 export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${VI_APPCLIENT_POLICY_FILE}"
 #export ANT_OPTS="${ANT_OPTS} -Djava.security.manager -Djava.security.policy==${ALLPERMISSION_POLICY_FILE}"
-ant ${ANT_ARG} config.vi.javadb
+ant ${CONFIG_ARG} ${ANT_ARG} config.vi.javadb
 echo "config vi ends here"
 ##### configVI.sh ends here #####
 
@@ -476,13 +477,13 @@ fi
 configRI() {
   ##### configRI.sh ends here #####
   cd  ${TS_HOME}/bin
-  ant ${ANT_ARG} config.ri
-  ant ${ANT_ARG} enable.csiv2
+  ant ${CONFIG_ARG} ${ANT_ARG} config.ri
+  ant ${CONFIG_ARG} ${ANT_ARG} enable.csiv2
   ##### configRI.sh ends here #####
 
   ##### addInteropCerts.sh starts here #####
   cd ${TS_HOME}/bin
-  ant ${ANT_ARG} add.interop.certs
+  ant ${CONFIG_ARG} ${ANT_ARG} add.interop.certs
   ##### addInteropCerts.sh ends here #####
 
   ### restartRI.sh starts here #####
@@ -509,7 +510,7 @@ fi
 
 if [[ "securityapi" == ${test_suite} ]]; then
   cd $TS_HOME/bin;
-  ant ${ANT_ARG} init.ldap
+  ant ${CONFIG_ARG} ${ANT_ARG} init.ldap
   echo "LDAP initilized for securityapi"
 fi
 
@@ -580,9 +581,9 @@ else
 fi
   # Generate combined report for both the runs.
 if [[ "jbatch" == ${test_suite} ]]; then
-  ant -Dreport.for=com/ibm/jbatch/tck -Dwork.dir=${JT_WORK_DIR}/jbatch -Dreport.dir=${JT_REPORT_DIR}/jbatch report
+  ant ${CONFIG_ARG} -Dreport.for=com/ibm/jbatch/tck -Dwork.dir=${JT_WORK_DIR}/jbatch -Dreport.dir=${JT_REPORT_DIR}/jbatch report
 else  
-  ant -Dreport.for=com/sun/ts/tests/$test_suite -Dreport.dir=${JT_REPORT_DIR}/${TEST_SUITE} -Dwork.dir=${JT_WORK_DIR}/${TEST_SUITE} report
+  ant ${CONFIG_ARG} -Dreport.for=com/sun/ts/tests/$test_suite -Dreport.dir=${JT_REPORT_DIR}/${TEST_SUITE} -Dwork.dir=${JT_WORK_DIR}/${TEST_SUITE} report
 fi
 
 fi

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -415,6 +415,7 @@ echo 'permission java.security.AllPermission;' >> ${ALLPERMISSION_POLICY_FILE}
 echo '};' >> ${ALLPERMISSION_POLICY_FILE}
 
 VI_SERVER_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/domains/domain1/config/server.policy
+echo '/* from jakartaeetck.sh for TCK tests */' >> ${VI_SERVER_POLICY_FILE}
 echo 'grant {' >> ${VI_SERVER_POLICY_FILE}
 # if [ "ejb30/sec" == "${test_suite}" ] || [ "webservices12" == "${test_suite}" ]; then
   #ejb30/sec fails with AllPermission

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -448,7 +448,7 @@ if [ "compat12" == "${test_suite}" ] || [ "connector" == "${test_suite}" ] || [ 
   echo 'permission "java.lang.RuntimePermission" "accessUserInformation";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "java.lang.RuntimePermission" "shutdownHooks";' >> ${VI_APPCLIENT_POLICY_FILE}
   echo 'permission "org.glassfish.pfl.basic.reflection.BridgePermission" "getBridge";' >> ${VI_APPCLIENT_POLICY_FILE}
-  echo 'permission "javax.xml.ws.WebServicePermission" "ConnectorPermission1_name2");' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "javax.xml.ws.WebServicePermission" "ConnectorPermission1_name2";' >> ${VI_APPCLIENT_POLICY_FILE}
 else
   echo "Setting AllPermission"
   echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}

--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -414,34 +414,34 @@ echo 'grant {' >> ${VI_SERVER_POLICY_FILE}
 if [ "ejb30/sec" == "${test_suite}" ]; then
   # ejb30/sec fails with AllPermission
   echo "Not setting AllPermission for ejb30/sec"
+  echo 'permission java.io.FilePermission "${com.sun.aas.instanceRoot}${/}generated${/}policy${/}-", "read,write,execute,delete";' >> ${VI_SERVER_POLICY_FILE}
+  echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_SERVER_POLICY_FILE}
 else
   echo "Setting AllPermission if not ejb30/sec"
   echo 'permission java.security.AllPermission;' >> ${VI_SERVER_POLICY_FILE}
 fi
-echo 'permission java.io.FilePermission "${com.sun.aas.instanceRoot}${/}generated${/}policy${/}-", "read,write,execute,delete";' >> ${VI_SERVER_POLICY_FILE}
-echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_SERVER_POLICY_FILE}
 echo '};' >> ${VI_SERVER_POLICY_FILE}
 
 VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy
 echo 'grant {' >> ${VI_APPCLIENT_POLICY_FILE}
 if [ "ejb30/sec" == "${test_suite}" ]; then
   # ejb30/sec fails with AllPermission
-  echo "Not setting AllPermission for ejb30/sec"
+  echo "Not setting AllPermission for ejb30/sec, enumerate the needed ones"
+  # If anybody want to continue in specifying all permissions, this is incomplete list:
+  echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "java.lang.RuntimePermission" "getClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "java.lang.RuntimePermission" "createClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "java.lang.RuntimePermission" "setContextClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "java.lang.RuntimePermission" "setIO";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "java.lang.RuntimePermission" "accessDeclaredMembers";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "java.lang.RuntimePermission" "getProtectionDomain";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "java.util.PropertyPermission" "*", "read, write";' >> ${VI_APPCLIENT_POLICY_FILE}
+  echo 'permission "java.io.FilePermission" "*", "execute, delete";' >> ${VI_APPCLIENT_POLICY_FILE}
 else
   echo "Setting AllPermission if not ejb30/sec"
   echo 'permission java.security.AllPermission;' >> ${VI_APPCLIENT_POLICY_FILE}
 fi
-# If anybody want to continue in specifying all permissions, this is incomplete list:
-echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_APPCLIENT_POLICY_FILE}
-echo 'permission "java.lang.RuntimePermission" "getenv.*";' >> ${VI_APPCLIENT_POLICY_FILE}
-echo 'permission "java.lang.RuntimePermission" "getClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
-echo 'permission "java.lang.RuntimePermission" "createClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
-echo 'permission "java.lang.RuntimePermission" "setContextClassLoader";' >> ${VI_APPCLIENT_POLICY_FILE}
-echo 'permission "java.lang.RuntimePermission" "setIO";' >> ${VI_APPCLIENT_POLICY_FILE}
-echo 'permission "java.lang.RuntimePermission" "accessDeclaredMembers";' >> ${VI_APPCLIENT_POLICY_FILE}
-echo 'permission "java.lang.RuntimePermission" "getProtectionDomain";' >> ${VI_APPCLIENT_POLICY_FILE}
-echo 'permission "java.util.PropertyPermission" "*", "read, write";' >> ${VI_APPCLIENT_POLICY_FILE}
-echo 'permission "java.io.FilePermission" "*", "execute, delete";' >> ${VI_APPCLIENT_POLICY_FILE}
 echo '};' >> ${VI_APPCLIENT_POLICY_FILE}
 
 mkdir -p ${JT_REPORT_DIR}

--- a/patch/run_jakartaeetck.sh
+++ b/patch/run_jakartaeetck.sh
@@ -248,8 +248,8 @@ unzip ${CTS_HOME}/javadb.zip -d $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR
 cp $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derbyclient.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/javadb/lib/derby.jar $CTS_HOME/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib
 rm ${CTS_HOME}/javadb.zip
 
-wget --progress=bar:force --no-cache $EJBTIMER_DERBY_SQL -O ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/ejbtimer_derby.sql
-wget --progress=bar:force --no-cache $JSR352_DERBY_SQL -O ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/jsr352-derby.sql
+cp $EJBTIMER_DERBY_SQL_PATH ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/ejbtimer_derby.sql
+cp $JSR352_DERBY_SQL_PATH ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/install/databases/jsr352-derby.sql
 
 if [[ $test_suite == ejb30/lite* ]] || [[ "ejb30" == $test_suite ]] ; then
   echo "Using higher JVM memory for EJB Lite suites to avoid OOM errors"

--- a/run.sh
+++ b/run.sh
@@ -151,7 +151,7 @@ if [ -z "$SKIP_TEST" ]; then
   echo "***********************************"
   echo "*            Payara LOGS          *"
   echo "***********************************"
-  cat $CTS_HOME/vi/payara6/glassfish/domains/domain1/logs/server.log
+  cat $CTS_HOME/vi/${GF_VI_TOPLEVEL_DIR}/glassfish/domains/domain1/logs/server.log
   echo "***********************************"
   echo "*        End of Payara LOGS       *"
   echo "***********************************"

--- a/run.sh
+++ b/run.sh
@@ -125,8 +125,8 @@ export GF_VI_BUNDLE_URL=$PAYARA_URL
 export PAYARA_VERSION=$PAYARA_VERSION
 export GF_VI_TOPLEVEL_DIR=payara5
 export DERBY_URL
-export EJBTIMER_DERBY_SQL
-export JSR352_DERBY_SQL
+export EJBTIMER_DERBY_SQL_PATH=./bundles/ejbtimer_derby.sql
+export JSR352_DERBY_SQL_PATH=./bundles/jsr352-derby.sql
 
 TEST_SUITE=`echo "$1" | tr '/' '_'`
 

--- a/run.sh
+++ b/run.sh
@@ -55,6 +55,9 @@ pkill -KILL -f glassfish
 if [ -z "$JAVA_HOME" ]; then
   export JAVA_HOME=`readlink -f /usr/bin/java | sed  "s:\(/jre\)\?/bin/java::"`
 fi
+echo "Remove trailing / from JAVA_HOME and JDK11_HOME, which causes problems in the TCK script"
+JAVA_HOME=$(echo "${JAVA_HOME}" | sed 's:/$::')
+JDK11_HOME=$(echo "${JDK11_HOME}" | sed 's:/$::')
 
 if [ -z "$SKIP_TCK" ]; then
     # clean cts directory

--- a/run.sh
+++ b/run.sh
@@ -71,8 +71,9 @@ if [ -z "$SKIP_TCK" ]; then
     rm -rf $CTS_HOME/*
     # download and unzip TCK
     TCK_TEMP=`mktemp --suffix .zip`
+    echo "Downloading TCK from $TCK_URL"
     curl $TCK_URL -o $TCK_TEMP
-    echo -n "Unzipping TCK... "
+    echo -n "Unzipping TCK to $CTS_HOME... "
     unzip -q -d $CTS_HOME $TCK_TEMP
     rm $TCK_TEMP
     cp $WORKSPACE/bin/ts.jte $CTS_HOME/ts.jte.dist

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2019, 2023 Payara Foundation and/or its affiliates. All rights reserved.
+# Copyright (c) 2019-2023 Payara Foundation and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -147,7 +147,17 @@ if [ -z "$SKIP_TEST" ]; then
   echo "Starting test!"
   time bash -x $SCRIPTPATH/jakartaeetck.sh "$@" |& tee $CTS_HOME/$TEST_SUITE.log
   ./asadmin stop-domain
+  # print Payara log
+  echo "***********************************"
+  echo "*            Payara LOGS          *"
+  echo "***********************************"
+  cat /home/ubuntu/workspace/TCK-Suite/cts_home/vi/payara6/glassfish/domains/domain1/logs/server.log
+  echo "***********************************"
+  echo "*        End of Payara LOGS       *"
+  echo "***********************************"
 fi
+
+
 # collect results
 
 summary=$CTS_HOME/jakartaeetck-report/${TEST_SUITE}/text/summary.txt

--- a/run.sh
+++ b/run.sh
@@ -151,7 +151,7 @@ if [ -z "$SKIP_TEST" ]; then
   echo "***********************************"
   echo "*            Payara LOGS          *"
   echo "***********************************"
-  cat /home/ubuntu/workspace/TCK-Suite/cts_home/vi/payara6/glassfish/domains/domain1/logs/server.log
+  cat $CTS_HOME/vi/payara6/glassfish/domains/domain1/logs/server.log
   echo "***********************************"
   echo "*        End of Payara LOGS       *"
   echo "***********************************"

--- a/run.sh
+++ b/run.sh
@@ -124,7 +124,7 @@ export DATABASE=JavaDB
 export GF_VI_BUNDLE_URL=$PAYARA_URL
 export PAYARA_VERSION=$PAYARA_VERSION
 export GF_VI_TOPLEVEL_DIR=payara5
-export DERBY_URL
+export DERBY_PATH=./bundles/javadb.zip
 export EJBTIMER_DERBY_SQL_PATH=./bundles/ejbtimer_derby.sql
 export JSR352_DERBY_SQL_PATH=./bundles/jsr352-derby.sql
 

--- a/run.sh
+++ b/run.sh
@@ -51,6 +51,13 @@ export WORKSPACE=$CTS_HOME/jakartaeetck
 echo "Cleaning and installing TCK"
 # kill any leftover glassfish/payara instances
 pkill -KILL -f glassfish
+# check the required ports
+echo Checking ports: 8080
+ss -tupanr | grep 8080
+echo Checking ports: 8181
+ss -tupanr | grep 8181
+echo Checking ports: 4848
+ss -tupanr | grep 4848
 
 if [ -z "$JAVA_HOME" ]; then
   export JAVA_HOME=`readlink -f /usr/bin/java | sed  "s:\(/jre\)\?/bin/java::"`


### PR DESCRIPTION
* Set `max.classes.restart` to high number, so CDI tests don't restart server during testing, it failed the next test after restart (restarted server although the previous test didn't finish), probably error in Arquillian or its Payara integration.
* Upgraded TCKs to jakarta-jakartaeetck-8.0.3.zip, mainly for refreshed certificates
* Set variables with tests/Derby URLs, so it's not dependant on Jenkins file
* specify security.policy files for both server and client; introduce `AllPermission` for ant scripts, which setup stuff like database. Some tests like `ejb/sec` cannot run with `AllPermission`, so they run with specific list.
* hardcode printing Payara log, because it is not sometimes available in artifacts

It is necessary to run the tests with the old Java 8, e.g. zulu-8.0.232!

The successful run with all TCKs passing: https://engineeringjenkins.payara.fish/blue/organizations/jenkins/TCK-Suite/detail/TCK-Suite/104/pipeline/