### PR TITLE
FISH-8191 Upgrade JAXB TCK to 4.0.1

### DIFF
--- a/bundles/download.sh
+++ b/bundles/download.sh
@@ -19,8 +19,8 @@ fi
 if [ ! -f jakarta-activation-tck-2.1.0.zip ]; then
 	wget https://download.eclipse.org/jakartaee/activation/2.1/jakarta-activation-tck-2.1.0.zip -O jakarta-activation-tck-2.1.0.zip
 fi
-if [ ! -f jakarta-xml-binding-tck-4.0.0.zip ]; then
-	wget https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.0.zip -O jakarta-xml-binding-tck-4.0.0.zip
+if [ ! -f jakarta-xml-binding-tck-4.0.1.zip ]; then
+	wget https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.1.zip -O jakarta-xml-binding-tck-4.0.1.zip
 fi
 if [ ! -f jakarta-debugging-tck-2.0.0.zip ]; then
 	wget https://download.eclipse.org/jakartaee/debugging/2.0/jakarta-debugging-tck-2.0.0.zip -O jakarta-debugging-tck-2.0.0.zip

--- a/functions.sh
+++ b/functions.sh
@@ -71,6 +71,10 @@ init_urls () {
     if [ -z "$BV_TCK_URL" ]; then
         BV_TCK_URL=$BASE_URL/bv-tck-3.0.1-dist.zip
     fi
+    if [ -z "$JAXB_TCK_URL" ]; then
+        JAXB_TCK_VERSION=4.0.1
+        JAXB_TCK_NAME=jakarta-xml-binding-tck-$JAXB_TCK_VERSION.zip
+    fi
     if [ -z "$DERBY_URL" ]; then
         DERBY_URL=$BASE_URL/javadb.zip
     fi

--- a/jaxb/build.sh
+++ b/jaxb/build.sh
@@ -12,8 +12,32 @@ init_urls
 PORTING=$SCRIPTPATH/jaxb-tck
 OUTPUT=$PORTING/bundles
 
+# be aware, that in the new version (since 4.0.2), defining $TCK_BUNDLE_BASE_URL causes the run_jaxbtck.sh script to stop in the middle (some way for specific script?)
+if [ -z "$TCK_BUNDLE_BASE_URL" ]; then
+  export TCK_BUNDLE_BASE_URL=http://localhost:8000
+fi
+if [ -z "$JAXB_TCK_VERSION" ]; then
+  # still no value? STOP
+  echo 'Specify $JAXB_TCK_VERSION before running this script, e.g. "4.0.1", used for tag name in JAXB git.'
+  exit 1
+fi
+if [ -z "$TCK_BUNDLE_FILE_NAME" ]; then
+  # use the name from init_urls
+  export TCK_BUNDLE_FILE_NAME=$JAXB_TCK_NAME
+fi
+if [ -z "$TCK_BUNDLE_FILE_NAME" ]; then
+  # still no value? STOP
+  echo 'Specify $JAXB_TCK_NAME before running this script, name of the JAXB TCK filename to download'
+  exit 1
+fi
+
 if [ ! -d jaxb-tck ]; then
-   git clone https://github.com/eclipse-ee4j/jaxb-tck
+  echo "Cloning JAXB git"
+  git clone https://github.com/eclipse-ee4j/jaxb-tck
+  cd jaxb-tck
+  echo "Checking out version $JAXB_TCK_VERSION"
+  git checkout $JAXB_TCK_VERSION
+  echo "Git clone and checkout done"
 fi
 
 rm -f $PORTING/latest-glassfish.zip
@@ -25,14 +49,12 @@ export WORKSPACE=$PORTING
 export GF_BUNDLE_URL=$PAYARA_URL
 echo Build should download from $GF_BUNDLE_URL
 
-if [ -z "$TCK_BUNDLE_BASE_URL" ]; then
-  export TCK_BUNDLE_BASE_URL=http://localhost:8000
-fi
-if [ -z "$TCK_BUNDLE_FILE_NAME" ]; then
-  export TCK_BUNDLE_FILE_NAME=jakarta-xml-binding-tck-4.0.0.zip
-fi
-
 # Substitute payara6 for glassfish7 for line: $GF_HOME/glassfish7/glassfish/
 sed -i "s/glassfish7/payara6/g" "$WORKSPACE/docker/build_jaxbtck.sh"
+
+# echo "Downloading Payara as the official script stopped to do it, storing to `pwd`"
+# cd jaxb-tck
+# wget --progress=bar:force --no-cache $GF_BUNDLE_URL -O latest-glassfish.zip
+# cd ..
 
 bash -x $WORKSPACE/docker/build_jaxbtck.sh

--- a/jaxb/run.sh
+++ b/jaxb/run.sh
@@ -14,11 +14,12 @@ export WORKSPACE=$PORTING
 export GF_BUNDLE_URL=$PAYARA_URL
 echo Build should download from $GF_BUNDLE_URL
 
+# be aware, that in the new version (since 4.0.2), defining $TCK_BUNDLE_BASE_URL causes the run_jaxbtck.sh script to stop in the middle (some way for specific script?)
 if [ -z "$TCK_BUNDLE_BASE_URL" ]; then
   export TCK_BUNDLE_BASE_URL=http://localhost:8000
 fi
 if [ -z "$TCK_BUNDLE_FILE_NAME" ]; then
-  export TCK_BUNDLE_FILE_NAME=jakarta-xml-binding-tck-4.0.0.zip
+  export TCK_BUNDLE_FILE_NAME=jakarta-xml-binding-tck-4.0.1.zip
 fi
 
 if [ -z $MAVEN_HOME ]; then
@@ -27,10 +28,6 @@ fi
 
 # Replace default value of ${$GF_TOPLEVEL_DIR} (glassfish7) with payara6
 sed -i "s/glassfish7/payara6/g" "$WORKSPACE/docker/run_jaxbtck.sh"
-
-# TCK Challenge
-# https://github.com/jakartaee/jaxb-tck/issues/82
-sed -i 's/xml-binding-tck\*.zip -d /xml-binding-tck*.zip -x "*IDREFS_length006*" -x "*NMTOKENS_length006*" -d /g' "$WORKSPACE/docker/run_jaxbtck.sh"
 
 # Make sure the script doesn't unset JAVA_HOME
 if [ -z "$JDK11_HOME" ]; then


### PR DESCRIPTION
Upgrade JAXB TCK to 4.0.1
Jenkins job: https://engineeringjenkins.payara.fish/blue/organizations/jenkins/TCK-Suite/detail/TCK-Suite/164/pipeline/

In the jaxb tck project, the script is now broken and the version is planned for 4.0.2, so this change checkouts directly version 4.0.1.
I added warnings and fixes for the next version as comments, but it will be necessary to accommodate it to the final version.

Version was moved to `functions.sh` to `init_urls` to the list of other versions, so they are defined in place.

I added some messages, what's going on for better debugging.