### PR TITLE
FISH-11490 Only Add Permission for Java 17

### DIFF
--- a/jakartaeetck.sh
+++ b/jakartaeetck.sh
@@ -462,7 +462,9 @@ echo 'permission java.net.SocketPermission "*", "listen";' >> ${VI_SERVER_POLICY
 echo 'permission java.net.SocketPermission "*", "accept";' >> ${VI_SERVER_POLICY_FILE}
 echo 'permission java.io.FilePermission       "<<ALL FILES>>", "write,read";' >> ${VI_SERVER_POLICY_FILE}
 echo 'permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";' >> ${VI_SERVER_POLICY_FILE}
-echo 'permission jakarta.xml.ws.WebServicePermission "CTSPermission3_name";' >> ${VI_SERVER_POLICY_FILE}
+if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]]; then
+  echo 'permission jakarta.xml.ws.WebServicePermission "CTSPermission3_name";' >> ${VI_SERVER_POLICY_FILE}
+fi
 echo '};' >> ${VI_SERVER_POLICY_FILE}
 
 VI_APPCLIENT_POLICY_FILE=${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/lib/appclient/client.policy


### PR DESCRIPTION
Follow-up to https://github.com/payara/jakartaeetck-runner/pull/100

Fixes the connector TCK breaking when using Java 11:
* Vanilla (unedited) failure: https://jenkins.payara.fish/blue/organizations/jenkins/TCK-Suite/detail/TCK-Suite/1062/pipeline/
* Edited success (this): https://jenkins.payara.fish/blue/organizations/jenkins/TCK-Suite/detail/TCK-Suite/1063/pipeline
* Reverted success: https://jenkins.payara.fish/blue/organizations/jenkins/TCK-Suite/detail/TCK-Suite/1061/pipeline/